### PR TITLE
refactor: make option upload-artifacts true by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run custom action
         uses: ./
-        with:
-          upload-artifacts: true

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ add the following options to your `dependents.yml` file if you want to customize
       max-pages: 50
       unique-owners: true
       exclude-owner: true
-      upload-artifacts: false
+      upload-artifacts: true
 ```
 
-| option             | type      | description                                                                 | default |
-|--------------------|-----------|-----------------------------------------------------------------------------|---------|
+| option             | type      | description                                                                  | default |
+|--------------------|-----------|------------------------------------------------------------------------------|---------|
 | `max-pages`        | `number`  | maximum number of network dependents pages to process (max: 100).            | `50`    |
 | `unique-owners`    | `boolean` | whether to disable unique users in the generated image.                      | `true`  |
 | `exclude-owner`    | `boolean` | whether to exclude repos from the same owner that depend on this repository. | `true`  |
-| `upload-artifacts` | `boolean` | whether to upload the outputs as action's build artifacts.                   | `false` |
+| `upload-artifacts` | `boolean` | whether to upload the outputs as action's build artifacts.                   | `true`  |
 
 ### embed image
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
   upload-artifacts:
     description: "Whether to upload the outputs as artifacts (true/false)"
     required: false
-    default: false
+    default: true
     type: boolean
 
 outputs:

--- a/www/index.html
+++ b/www/index.html
@@ -125,7 +125,7 @@
             <td class="sm:whitespace-nowrap"><code>upload-artifacts</code></td>
             <td class="max-sm:hidden"><code>boolean</code></td>
             <td>whether to upload the outputs as action's build artifacts.</td>
-            <td><code>false</code></td>
+            <td><code>true</code></td>
           </tr>
         </tbody>
       </table>
@@ -198,7 +198,7 @@ jobs:
     max-pages: 50
     unique-owners: true
     exclude-owner: true
-    upload-artifacts: false`;
+    upload-artifacts: true`;
 
       const htmlContent = (name) => `<a href="https://github.com/${name || "owner/repo"}/network/dependents">
   <img src="https://dependents.info/${name || "owner/repo"}/image.svg" />


### PR DESCRIPTION
Considering it is hard to debug when an action fails, made the option `upload-artifacts` (action generated JSON data) true by default.