### PR TITLE
feat: support more customizations for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ if you've used the `package-id` option in the action, this should be:
 
 available query params (optional):
 
+- `logo`: icon name from [simple-icons](https://simpleicons.org).
+- `label`: override the default label "dependents".
 - `color`: hex, rgb, rgba, hsl, hsla or css named color.
+- `logoColor`: hex, rgb, rgba, hsl, hsla or css named color.
 - `style`: [`flat` (default), `flat-square`, `plastic`, `for-the-badge`, `social`]
 
 usage: `/badge?color=red&style=flat-square`

--- a/api/internal/handlers/badge.go
+++ b/api/internal/handlers/badge.go
@@ -37,8 +37,11 @@ func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
 	totalInt, _ := strconv.Atoi(total)
 	u := "https://img.shields.io/badge/dependents-" + utils.FormatNumber(totalInt) + "-" + color(total)
 	url := utils.SetParams(u, map[string]string{
-		"style": c.Query("style"),
-		"color": c.Query("color"),
+		"logo":      c.Query("logo"),
+		"label":     c.Query("label"),
+		"style":     c.Query("style"),
+		"color":     c.Query("color"),
+		"logoColor": c.Query("logoColor"),
 	})
 
 	statusCode, body, errs := fiber.Get(url).Bytes()

--- a/www/index.html
+++ b/www/index.html
@@ -268,7 +268,10 @@
       <p>
         available query params (optional):
         <ul>
+          <li><code>logo</code>: icon name from <a href="https://simpleicons.org" target="_blank" rel="noopener noreferrer">simple-icons</a>.</li>
+          <li><code>label</code>: override the default label "dependents".</li>
           <li><code>color</code>: hex, rgb, rgba, hsl, hsla or css named color.</li>
+          <li><code>logoColor</code>: hex, rgb, rgba, hsl, hsla or css named color.</li>
           <li><code>style</code>: [flat (default), flat-square, plastic, for-the-badge, social]</li>
         </ul>
         usage: <code>/badge?color=red&style=flat-square</code>


### PR DESCRIPTION
adds support for query params `label`, `logo` & `logoColor` on the badges endpoint.