### PR TITLE
feat(api): sort fetched dependents before saving

### DIFF
--- a/api/internal/models/models.go
+++ b/api/internal/models/models.go
@@ -18,6 +18,7 @@ type IngestRequest struct {
 }
 
 type Dependent struct {
+	Stars int    `json:"stars,omitempty"`
 	Image string `json:"image" validate:"required,startswith=data:image/,contains=base64"`
 }
 

--- a/api/internal/service/github/dependents.go
+++ b/api/internal/service/github/dependents.go
@@ -39,7 +39,7 @@ func (s *DependentsService) NewTask(repo string, id string, kind string, callbac
 		}
 		return
 	}
-	dependents, err := utils.ParseDependents(page, repo)
+	dependents, err := utils.ParseDependents(page)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
the network dependents ingested from the github action are sorted based on stars in the action itself, before sending to the api for ingestion.

in case the github action is not used and an image for a repository is requested, the api itself fetches them.

this PR adds logic to sort network dependents on the api level as well.