### PR TITLE
refactor(api): isolate scrape and test handlers

### DIFF
--- a/api/internal/handlers/badge.go
+++ b/api/internal/handlers/badge.go
@@ -7,22 +7,21 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/github"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type BadgeHandler struct {
-	dependentsService *github.DependentsService
-	databaseService   *database.BadgerService
+	dependentsService service.DependentsTasker
+	store             service.Store
 }
 
 func NewBadgeHandler(
-	databaseService *database.BadgerService,
-	dependentsService *github.DependentsService,
+	store service.Store,
+	dependentsService service.DependentsTasker,
 ) *BadgeHandler {
 	return &BadgeHandler{
-		databaseService:   databaseService,
+		store:             store,
 		dependentsService: dependentsService,
 	}
 }
@@ -34,12 +33,15 @@ func (h *BadgeHandler) resolveTotal(repo, id string) (string, error) {
 	}
 
 	var total string
-	err := h.databaseService.Get("total:"+name, &total)
+	err := h.store.Get("total:"+name, &total)
 	if err != nil {
-		h.dependentsService.NewTask(repo, id, "badge", func(total int, svg []byte) {
-			h.databaseService.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
+		taskErr := h.dependentsService.NewTask(repo, id, "badge", func(total int, svg []byte) {
+			_ = h.store.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
 		})
-		err = h.databaseService.Get("total:"+name, &total)
+		if taskErr != nil {
+			return "", taskErr
+		}
+		err = h.store.Get("total:"+name, &total)
 	}
 	return total, err
 }
@@ -84,7 +86,7 @@ func (h *BadgeHandler) Shields(c *fiber.Ctx) error {
 func (h *BadgeHandler) SelfBadge(c *fiber.Ctx) error {
 	var total string
 	seen := make(map[string]struct{})
-	h.databaseService.IterateKeys(func(key string) {
+	h.store.IterateKeys(func(key string) {
 		route := utils.ToRoute(key)
 		if _, exists := seen[route]; !exists {
 			seen[route] = struct{}{}

--- a/api/internal/handlers/badge.go
+++ b/api/internal/handlers/badge.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -26,7 +27,7 @@ func NewBadgeHandler(
 	}
 }
 
-func (h *BadgeHandler) resolveTotal(repo, id string) (string, error) {
+func (h *BadgeHandler) resolveTotal(ctx context.Context, repo, id string) (string, error) {
 	name := repo
 	if id != "" {
 		name += ":" + id
@@ -35,7 +36,7 @@ func (h *BadgeHandler) resolveTotal(repo, id string) (string, error) {
 	var total string
 	err := h.store.Get("total:"+name, &total)
 	if err != nil {
-		taskErr := h.dependentsService.NewTask(repo, id, "badge", func(total int, svg []byte) {
+		taskErr := h.dependentsService.NewTask(ctx, repo, id, "badge", func(total int, svg []byte) {
 			_ = h.store.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
 		})
 		if taskErr != nil {
@@ -50,7 +51,7 @@ func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
 	id := c.Query("id")
 	repo := c.Params("owner") + "/" + c.Params("repo")
 
-	total, err := h.resolveTotal(repo, id)
+	total, err := h.resolveTotal(c.UserContext(), repo, id)
 	if err != nil {
 		return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
 	}
@@ -66,7 +67,7 @@ func (h *BadgeHandler) Shields(c *fiber.Ctx) error {
 	id := c.Query("id")
 	repo := c.Params("owner") + "/" + c.Params("repo")
 
-	total, err := h.resolveTotal(repo, id)
+	total, err := h.resolveTotal(c.UserContext(), repo, id)
 	if err != nil {
 		return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
 	}

--- a/api/internal/handlers/badge_test.go
+++ b/api/internal/handlers/badge_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -49,7 +50,7 @@ func TestBadgeHandler_Badge(t *testing.T) {
 			}
 
 			depService := &test.MockDependentsTasker{
-				NewTaskFn: func(repo, id, kind string, callback func(int, []byte)) error {
+				NewTaskFn: func(_ context.Context, repo, id, kind string, callback func(int, []byte)) error {
 					if tt.taskErr != nil {
 						return tt.taskErr
 					}

--- a/api/internal/handlers/badge_test.go
+++ b/api/internal/handlers/badge_test.go
@@ -2,15 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
 
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/github"
-	"dependents.info/internal/service/render"
 	"dependents.info/internal/test"
 )
 
@@ -19,36 +17,51 @@ func TestBadgeHandler_Badge(t *testing.T) {
 		name           string
 		url            string
 		expectedStatus int
+		storeData      map[string][]byte
+		taskErr        error
 	}{
 		{
-			name:           "valid request",
+			name:           "cached total returns badge",
+			url:            "/owner/repo/badge",
+			expectedStatus: fiber.StatusOK,
+			storeData:      map[string][]byte{"total:owner/repo": []byte("69")},
+		},
+		{
+			name:           "fallback via NewTask succeeds",
 			url:            "/owner/repo/badge",
 			expectedStatus: fiber.StatusOK,
 		},
 		{
-			name:           "non-existent badge",
-			url:            "/invalid/repo/badge",
+			name:           "fallback via NewTask fails",
+			url:            "/owner/repo/badge",
 			expectedStatus: fiber.StatusNotFound,
-		},
-		{
-			name:           "self",
-			url:            "/self/repo/badge",
-			expectedStatus: fiber.StatusOK,
+			taskErr:        errors.New("fetch failed"),
 		},
 	}
 
 	cfg := test.NewConfig()
-	imageService := render.NewRenderService()
-	dbService := database.NewBadgerService(cfg.DatabasePath)
-	dependentsService := github.NewDependentsService(imageService)
-	dbService.Save("total:owner/repo", []byte("69"))
-	defer dbService.Close()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			store := test.NewMockStore()
+			for k, v := range tt.storeData {
+				store.Save(k, v)
+			}
+
+			depService := &test.MockDependentsTasker{
+				NewTaskFn: func(repo, id, kind string, callback func(int, []byte)) error {
+					if tt.taskErr != nil {
+						return tt.taskErr
+					}
+					if callback != nil {
+						callback(100, nil)
+					}
+					return nil
+				},
+			}
+
 			app := test.NewServer(cfg)
-			h := NewBadgeHandler(dbService, dependentsService)
-			app.Get("/self/repo/badge", h.SelfBadge)
+			h := NewBadgeHandler(store, depService)
 			app.Get("/:owner/:repo/badge", h.Badge)
 
 			req := httptest.NewRequest("GET", tt.url, nil)
@@ -65,16 +78,12 @@ func TestBadgeHandler_Badge(t *testing.T) {
 
 func TestBadgeHandler_Shields(t *testing.T) {
 	cfg := test.NewConfig()
-	cfg.DatabasePath = "/tmp/dependents-test-shields"
-	imageService := render.NewRenderService()
-	dbService := database.NewBadgerService(cfg.DatabasePath)
-	dependentsService := github.NewDependentsService(imageService)
-	dbService.Save("total:owner/repo", []byte("69"))
-	dbService.Save("total:owner/repo:pkg1", []byte("1200"))
-	defer dbService.Close()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo", []byte("69"))
+	store.Save("total:owner/repo:pkg1", []byte("1200"))
 
 	app := test.NewServer(cfg)
-	h := NewBadgeHandler(dbService, dependentsService)
+	h := NewBadgeHandler(store, &test.MockDependentsTasker{})
 	app.Get("/:owner/:repo/shields.json", h.Shields)
 
 	t.Run("cached total", func(t *testing.T) {
@@ -140,4 +149,66 @@ func TestBadgeHandler_Shields(t *testing.T) {
 			t.Errorf("expected 404, got %d", resp.StatusCode)
 		}
 	})
+}
+
+func TestBadgeHandler_SelfBadge(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	store.Save("total:owner1/repo1", []byte("10"))
+	store.Save("svg:owner1/repo1", []byte("<svg/>"))
+	store.Save("total:owner2/repo2", []byte("20"))
+
+	app := test.NewServer(cfg)
+	h := NewBadgeHandler(store, &test.MockDependentsTasker{})
+	app.Get("/self/badge", h.SelfBadge)
+
+	req := httptest.NewRequest("GET", "/self/badge", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestBadgeHandler_Badge_WithQueryId(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo:pkg123", []byte("42"))
+
+	app := test.NewServer(cfg)
+	h := NewBadgeHandler(store, &test.MockDependentsTasker{})
+	app.Get("/:owner/:repo/badge", h.Badge)
+
+	req := httptest.NewRequest("GET", "/owner/repo/badge?id=pkg123", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestColorFunction(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"0", "red"},
+		{"-1", "red"},
+		{"5", "yellow"},
+		{"50", "yellowgreen"},
+		{"500", "green"},
+		{"5000", "brightgreen"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := color(tt.input)
+			if got != tt.want {
+				t.Errorf("color(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }

--- a/api/internal/handlers/delete.go
+++ b/api/internal/handlers/delete.go
@@ -4,17 +4,17 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"dependents.info/internal/config"
-	"dependents.info/internal/service/database"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type DeleteHandler struct {
-	databaseService *database.BadgerService
+	store service.Store
 }
 
-func NewDeleteHandler(databaseService *database.BadgerService) *DeleteHandler {
+func NewDeleteHandler(store service.Store) *DeleteHandler {
 	return &DeleteHandler{
-		databaseService: databaseService,
+		store: store,
 	}
 }
 
@@ -35,7 +35,7 @@ func (h *DeleteHandler) Delete(c *fiber.Ctx) error {
 
 	keys := []string{"total:" + name, "svg:" + name}
 	for _, key := range keys {
-		err = h.databaseService.Delete(key)
+		err = h.store.Delete(key)
 		if err != nil {
 			return utils.SendError(c, fiber.StatusInternalServerError, "Failed to delete "+key, err)
 		}

--- a/api/internal/handlers/delete_test.go
+++ b/api/internal/handlers/delete_test.go
@@ -1,13 +1,11 @@
 package handlers
 
 import (
-	"log"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
 
-	"dependents.info/internal/service/database"
 	"dependents.info/internal/test"
 )
 
@@ -19,7 +17,7 @@ func TestDeleteHandler_Delete(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name:           "error",
+			name:           "wrong password",
 			repo:           "owner/repo",
 			password:       "wrongpassword",
 			expectedStatus: fiber.StatusUnauthorized,
@@ -33,27 +31,15 @@ func TestDeleteHandler_Delete(t *testing.T) {
 	}
 
 	cfg := test.NewConfig()
-	dbService := database.NewBadgerService(cfg.DatabasePath)
-	defer dbService.Close()
-
-	dbService.Save("total:owner:repo", []byte("69420"))
-	dbService.Save("svg:owner:repo", []byte("some svg string"))
-
-	var data string
-	dbService.Get("total:owner:repo", &data)
-	log.Print(data)
-	if data == "" {
-		t.Fatalf("no totals count set for test repo")
-	}
-	dbService.Get("svg:owner:repo", &data)
-	if data == "" {
-		t.Fatalf("no svg image set for test repo")
-	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			store := test.NewMockStore()
+			store.Save("total:owner/repo", []byte("69420"))
+			store.Save("svg:owner/repo", []byte("some svg string"))
+
 			app := test.NewServer(cfg)
-			h := NewDeleteHandler(dbService)
+			h := NewDeleteHandler(store)
 			app.Delete("/:owner/:repo", h.Delete)
 			req := httptest.NewRequest("DELETE", "/"+tt.repo, nil)
 			req.Header.Set("Authorization", "Bearer "+tt.password)
@@ -65,5 +51,69 @@ func TestDeleteHandler_Delete(t *testing.T) {
 				t.Errorf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
 			}
 		})
+	}
+}
+
+func TestDeleteHandler_Delete_RemovesKeys(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo", []byte("100"))
+	store.Save("svg:owner/repo", []byte("<svg/>"))
+
+	app := test.NewServer(cfg)
+	h := NewDeleteHandler(store)
+	app.Delete("/:owner/:repo", h.Delete)
+
+	req := httptest.NewRequest("DELETE", "/owner/repo", nil)
+	req.Header.Set("Authorization", "Bearer admin")
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	var out string
+	if err := store.Get("total:owner/repo", &out); err == nil {
+		t.Error("expected total key to be deleted")
+	}
+	if err := store.Get("svg:owner/repo", &out); err == nil {
+		t.Error("expected svg key to be deleted")
+	}
+}
+
+func TestDeleteHandler_Delete_WithQueryId(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo:pkgId", []byte("50"))
+	store.Save("svg:owner/repo:pkgId", []byte("<svg/>"))
+
+	app := test.NewServer(cfg)
+	h := NewDeleteHandler(store)
+	app.Delete("/:owner/:repo", h.Delete)
+
+	req := httptest.NewRequest("DELETE", "/owner/repo?id=pkgId", nil)
+	req.Header.Set("Authorization", "Bearer admin")
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	var out string
+	if err := store.Get("total:owner/repo:pkgId", &out); err == nil {
+		t.Error("expected total key to be deleted")
+	}
+}
+
+func TestDeleteHandler_Delete_MissingAuth(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+
+	app := test.NewServer(cfg)
+	h := NewDeleteHandler(store)
+	app.Delete("/:owner/:repo", h.Delete)
+
+	req := httptest.NewRequest("DELETE", "/owner/repo", nil)
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
 	}
 }

--- a/api/internal/handlers/handlers.go
+++ b/api/internal/handlers/handlers.go
@@ -14,24 +14,24 @@ type Handlers struct {
 
 func BuildAll(services *service.Services) *Handlers {
 	healthHandler := NewHealthHandler()
-	deleteHandler := NewDeleteHandler(services.DatabaseService)
-	imageHandler := NewImageHandler(services.DatabaseService, services.DependentsService)
+	deleteHandler := NewDeleteHandler(services.Store)
+	imageHandler := NewImageHandler(services.Store, services.DependentsService)
 	badgeHandler := NewBadgeHandler(
-		services.DatabaseService,
+		services.Store,
 		services.DependentsService,
 	)
 	sitemapHandler := NewSitemapHandler(
-		services.DatabaseService,
-		services.RenderService,
+		services.Store,
+		services.Renderer,
 	)
 	repoHandler := NewRepoHandler(
-		services.DatabaseService,
-		services.RenderService,
+		services.Store,
+		services.Renderer,
 	)
 	ingestHandler := NewIngestHandler(
-		services.GitHubOIDCService,
-		services.DatabaseService,
-		services.RenderService,
+		services.OIDCVerifier,
+		services.Store,
+		services.Renderer,
 	)
 
 	return &Handlers{

--- a/api/internal/handlers/image.go
+++ b/api/internal/handlers/image.go
@@ -6,22 +6,21 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/github"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type ImageHandler struct {
-	dependentsService *github.DependentsService
-	databaseService   *database.BadgerService
+	dependentsService service.DependentsTasker
+	store             service.Store
 }
 
 func NewImageHandler(
-	databaseService *database.BadgerService,
-	dependentsService *github.DependentsService,
+	store service.Store,
+	dependentsService service.DependentsTasker,
 ) *ImageHandler {
 	return &ImageHandler{
-		databaseService:   databaseService,
+		store:             store,
 		dependentsService: dependentsService,
 	}
 }
@@ -36,14 +35,17 @@ func (h *ImageHandler) SVGImage(c *fiber.Ctx) error {
 	}
 
 	var svg string
-	err := h.databaseService.Get("svg:"+name, &svg)
+	err := h.store.Get("svg:"+name, &svg)
 
 	if err != nil {
-		h.dependentsService.NewTask(repo, id, "image", func(total int, svg []byte) {
-			h.databaseService.SaveWithTTL("svg:"+name, svg, 7*24*time.Hour)
-			h.databaseService.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
+		taskErr := h.dependentsService.NewTask(repo, id, "image", func(total int, svg []byte) {
+			_ = h.store.SaveWithTTL("svg:"+name, svg, 7*24*time.Hour)
+			_ = h.store.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
 		})
-		err = h.databaseService.Get("svg:"+name, &svg)
+		if taskErr != nil {
+			return utils.SendError(c, fiber.StatusNotFound, "SVG image not found", taskErr)
+		}
+		err = h.store.Get("svg:"+name, &svg)
 		if err != nil {
 			return utils.SendError(c, fiber.StatusNotFound, "SVG image not found", err)
 		}

--- a/api/internal/handlers/image.go
+++ b/api/internal/handlers/image.go
@@ -38,7 +38,7 @@ func (h *ImageHandler) SVGImage(c *fiber.Ctx) error {
 	err := h.store.Get("svg:"+name, &svg)
 
 	if err != nil {
-		taskErr := h.dependentsService.NewTask(repo, id, "image", func(total int, svg []byte) {
+		taskErr := h.dependentsService.NewTask(c.UserContext(), repo, id, "image", func(total int, svg []byte) {
 			_ = h.store.SaveWithTTL("svg:"+name, svg, 7*24*time.Hour)
 			_ = h.store.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
 		})

--- a/api/internal/handlers/image_test.go
+++ b/api/internal/handlers/image_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ func TestImageHandler_SVGImage(t *testing.T) {
 		name           string
 		url            string
 		storeData      map[string][]byte
-		taskFn         func(string, string, string, func(int, []byte)) error
+		taskFn         func(context.Context, string, string, string, func(int, []byte)) error
 		expectedStatus int
 		expectedBody   string
 	}{
@@ -30,7 +31,7 @@ func TestImageHandler_SVGImage(t *testing.T) {
 		{
 			name: "fallback via NewTask succeeds",
 			url:  "/owner/repo/image",
-			taskFn: func(repo, id, kind string, cb func(int, []byte)) error {
+			taskFn: func(_ context.Context, repo, id, kind string, cb func(int, []byte)) error {
 				if cb != nil {
 					cb(10, []byte("<svg>fresh</svg>"))
 				}
@@ -42,7 +43,7 @@ func TestImageHandler_SVGImage(t *testing.T) {
 		{
 			name: "fallback via NewTask fails",
 			url:  "/owner/repo/image",
-			taskFn: func(_, _, _ string, _ func(int, []byte)) error {
+			taskFn: func(_ context.Context, _, _, _ string, _ func(int, []byte)) error {
 				return errors.New("fetch failed")
 			},
 			expectedStatus: fiber.StatusNotFound,

--- a/api/internal/handlers/image_test.go
+++ b/api/internal/handlers/image_test.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"dependents.info/internal/test"
+)
+
+func TestImageHandler_SVGImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		storeData      map[string][]byte
+		taskFn         func(string, string, string, func(int, []byte)) error
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "cached svg returned",
+			url:            "/owner/repo/image",
+			storeData:      map[string][]byte{"svg:owner/repo": []byte("<svg>cached</svg>")},
+			expectedStatus: fiber.StatusOK,
+			expectedBody:   "<svg>cached</svg>",
+		},
+		{
+			name: "fallback via NewTask succeeds",
+			url:  "/owner/repo/image",
+			taskFn: func(repo, id, kind string, cb func(int, []byte)) error {
+				if cb != nil {
+					cb(10, []byte("<svg>fresh</svg>"))
+				}
+				return nil
+			},
+			expectedStatus: fiber.StatusOK,
+			expectedBody:   "<svg>fresh</svg>",
+		},
+		{
+			name: "fallback via NewTask fails",
+			url:  "/owner/repo/image",
+			taskFn: func(_, _, _ string, _ func(int, []byte)) error {
+				return errors.New("fetch failed")
+			},
+			expectedStatus: fiber.StatusNotFound,
+		},
+		{
+			name:           "with package id",
+			url:            "/owner/repo/image?id=pkg1",
+			storeData:      map[string][]byte{"svg:owner/repo:pkg1": []byte("<svg>pkg</svg>")},
+			expectedStatus: fiber.StatusOK,
+			expectedBody:   "<svg>pkg</svg>",
+		},
+	}
+
+	cfg := test.NewConfig()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := test.NewMockStore()
+			for k, v := range tt.storeData {
+				store.Save(k, v)
+			}
+
+			depService := &test.MockDependentsTasker{NewTaskFn: tt.taskFn}
+			app := test.NewServer(cfg)
+			h := NewImageHandler(store, depService)
+			app.Get("/:owner/:repo/image", h.SVGImage)
+
+			req := httptest.NewRequest("GET", tt.url, nil)
+			resp, err := app.Test(req, -1)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+			if tt.expectedBody != "" {
+				body, _ := io.ReadAll(resp.Body)
+				if string(body) != tt.expectedBody {
+					t.Errorf("expected body %q, got %q", tt.expectedBody, string(body))
+				}
+			}
+		})
+	}
+}

--- a/api/internal/handlers/ingest.go
+++ b/api/internal/handlers/ingest.go
@@ -8,27 +8,25 @@ import (
 	"dependents.info/internal/config"
 	"dependents.info/internal/env"
 	"dependents.info/internal/models"
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/github"
-	"dependents.info/internal/service/render"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type IngestHandler struct {
-	githubOIDCService *github.OIDCService
-	renderService     *render.RenderService
-	databaseService   *database.BadgerService
+	oidcVerifier service.OIDCVerifier
+	renderer     service.Renderer
+	store        service.Store
 }
 
 func NewIngestHandler(
-	githubOIDC *github.OIDCService,
-	dbService *database.BadgerService,
-	renderService *render.RenderService,
+	oidcVerifier service.OIDCVerifier,
+	store service.Store,
+	renderer service.Renderer,
 ) *IngestHandler {
 	return &IngestHandler{
-		databaseService:   dbService,
-		githubOIDCService: githubOIDC,
-		renderService:     renderService,
+		store:        store,
+		oidcVerifier: oidcVerifier,
+		renderer:     renderer,
 	}
 }
 
@@ -47,7 +45,7 @@ func (h *IngestHandler) Ingest(c *fiber.Ctx) error {
 			return utils.SendError(c, fiber.StatusUnauthorized, "Invalid Authorization header", err)
 		}
 
-		if err := h.githubOIDCService.VerifyToken(c.Context(), token, name); err != nil {
+		if err := h.oidcVerifier.VerifyToken(c.Context(), token, name); err != nil {
 			return utils.SendError(c, fiber.StatusUnauthorized, "Repository ownership verification failed", err)
 		}
 	}
@@ -61,7 +59,7 @@ func (h *IngestHandler) Ingest(c *fiber.Ctx) error {
 		return utils.SendError(c, fiber.StatusBadRequest, "Invalid JSON payload", err)
 	}
 
-	svgBytes, err := h.renderService.RenderSVG(req)
+	svgBytes, err := h.renderer.RenderSVG(req)
 	if err != nil {
 		return utils.SendError(c, fiber.StatusInternalServerError, "Failed to render SVG", err)
 	}
@@ -70,11 +68,11 @@ func (h *IngestHandler) Ingest(c *fiber.Ctx) error {
 		name += ":" + id
 	}
 
-	if err := h.databaseService.Save("total:"+name, []byte(strconv.Itoa(req.Total))); err != nil {
+	if err := h.store.Save("total:"+name, []byte(strconv.Itoa(req.Total))); err != nil {
 		return utils.SendError(c, fiber.StatusInternalServerError, "Failed to store total dependents", err)
 	}
 
-	if err := h.databaseService.Save("svg:"+name, svgBytes); err != nil {
+	if err := h.store.Save("svg:"+name, svgBytes); err != nil {
 		return utils.SendError(c, fiber.StatusInternalServerError, "Failed to store SVG", err)
 	}
 

--- a/api/internal/handlers/ingest_test.go
+++ b/api/internal/handlers/ingest_test.go
@@ -3,14 +3,14 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
 
+	"dependents.info/internal/env"
 	"dependents.info/internal/models"
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/render"
 	"dependents.info/internal/test"
 )
 
@@ -20,6 +20,7 @@ func TestIngestHandler_Ingest(t *testing.T) {
 		requestBody    any
 		expectedStatus int
 		expectedMsg    string
+		renderErr      error
 	}{
 		{
 			name:           "empty request body",
@@ -56,6 +57,18 @@ func TestIngestHandler_Ingest(t *testing.T) {
 			expectedStatus: fiber.StatusBadRequest,
 		},
 		{
+			name: "render failure",
+			requestBody: models.IngestRequest{
+				Total: 10,
+				Dependents: []models.Dependent{
+					{Image: "data:image/png;base64,r4nd0m=="},
+				},
+			},
+			renderErr:      errors.New("render failed"),
+			expectedStatus: fiber.StatusInternalServerError,
+			expectedMsg:    "Failed to render SVG",
+		},
+		{
 			name: "success",
 			requestBody: models.IngestRequest{
 				Total: 10,
@@ -71,14 +84,17 @@ func TestIngestHandler_Ingest(t *testing.T) {
 	}
 
 	cfg := test.NewConfig()
-	renderService := render.NewRenderService()
-	dbService := database.NewBadgerService(cfg.DatabasePath)
-	defer dbService.Close()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			store := test.NewMockStore()
+			renderer := &test.MockRenderer{
+				SVGResult: []byte("<svg>test</svg>"),
+				SVGErr:    tt.renderErr,
+			}
+
 			app := test.NewServer(cfg)
-			h := NewIngestHandler(nil, dbService, renderService)
+			h := NewIngestHandler(nil, store, renderer)
 			app.Post("/ingest", h.Ingest)
 
 			var reqBody []byte
@@ -109,4 +125,91 @@ func TestIngestHandler_Ingest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIngestHandler_Ingest_StoresData(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	renderer := &test.MockRenderer{SVGResult: []byte("<svg>ok</svg>")}
+
+	app := test.NewServer(cfg)
+	h := NewIngestHandler(nil, store, renderer)
+	app.Post("/:owner/:repo/ingest", h.Ingest)
+
+	body := models.IngestRequest{
+		Total:      42,
+		Dependents: []models.Dependent{{Image: "data:image/png;base64,abc="}},
+	}
+	reqBody, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/owner/repo/ingest", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var total string
+	if err := store.Get("total:owner/repo", &total); err != nil {
+		t.Fatal("total not stored")
+	}
+	if total != "42" {
+		t.Errorf("expected total '42', got %q", total)
+	}
+
+	var svg string
+	if err := store.Get("svg:owner/repo", &svg); err != nil {
+		t.Fatal("svg not stored")
+	}
+	if svg != "<svg>ok</svg>" {
+		t.Errorf("expected svg '<svg>ok</svg>', got %q", svg)
+	}
+}
+
+func TestIngestHandler_Ingest_ProductionAuth(t *testing.T) {
+	cfg := test.NewConfig()
+	cfg.Environment = env.EnvProduction
+
+	t.Run("missing token", func(t *testing.T) {
+		store := test.NewMockStore()
+		renderer := &test.MockRenderer{SVGResult: []byte("<svg/>")}
+		app := test.NewServer(cfg)
+		h := NewIngestHandler(&test.MockOIDCVerifier{}, store, renderer)
+		app.Post("/:owner/:repo/ingest", h.Ingest)
+
+		body, _ := json.Marshal(models.IngestRequest{
+			Total:      1,
+			Dependents: []models.Dependent{{Image: "data:image/png;base64,x="}},
+		})
+		req := httptest.NewRequest("POST", "/owner/repo/ingest", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := app.Test(req, -1)
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		store := test.NewMockStore()
+		renderer := &test.MockRenderer{SVGResult: []byte("<svg/>")}
+		oidc := &test.MockOIDCVerifier{Err: errors.New("bad token")}
+		app := test.NewServer(cfg)
+		h := NewIngestHandler(oidc, store, renderer)
+		app.Post("/:owner/:repo/ingest", h.Ingest)
+
+		body, _ := json.Marshal(models.IngestRequest{
+			Total:      1,
+			Dependents: []models.Dependent{{Image: "data:image/png;base64,x="}},
+		})
+		req := httptest.NewRequest("POST", "/owner/repo/ingest", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer fake-token")
+		resp, _ := app.Test(req, -1)
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
 }

--- a/api/internal/handlers/repo.go
+++ b/api/internal/handlers/repo.go
@@ -9,20 +9,19 @@ import (
 
 	"dependents.info/internal/config"
 	"dependents.info/internal/models"
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/render"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type RepoHandler struct {
-	renderService   *render.RenderService
-	databaseService *database.BadgerService
+	renderer service.Renderer
+	store    service.Store
 }
 
-func NewRepoHandler(databaseService *database.BadgerService, renderService *render.RenderService) *RepoHandler {
+func NewRepoHandler(store service.Store, renderer service.Renderer) *RepoHandler {
 	return &RepoHandler{
-		renderService:   renderService,
-		databaseService: databaseService,
+		renderer: renderer,
+		store:    store,
 	}
 }
 
@@ -49,7 +48,7 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 	}
 
 	var total string
-	err := h.databaseService.Get("total:"+name, &total)
+	err := h.store.Get("total:"+name, &total)
 
 	if err != nil {
 		if format != "html" {
@@ -64,7 +63,7 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 	}
 
 	var image string
-	err = h.databaseService.Get("svg:"+name, &image)
+	err = h.store.Get("svg:"+name, &image)
 	if err != nil {
 		image = ""
 	}
@@ -90,7 +89,7 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 		Id:         id,
 	}
 
-	page, err := h.renderService.RenderPage(data)
+	page, err := h.renderer.RenderPage(data)
 
 	if err != nil {
 		return utils.SendError(c, fiber.StatusNotFound, "Failed to generate repository page", err)

--- a/api/internal/handlers/repo_test.go
+++ b/api/internal/handlers/repo_test.go
@@ -9,22 +9,88 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/render"
 	"dependents.info/internal/test"
 )
 
+func TestRepoHandler_RepoPage(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		storeData      map[string][]byte
+		pageResult     []byte
+		expectedStatus int
+	}{
+		{
+			name:           "redirect when no data cached",
+			url:            "/owner/repo",
+			expectedStatus: fiber.StatusTemporaryRedirect,
+		},
+		{
+			name:           "render page with total",
+			url:            "/owner/repo",
+			storeData:      map[string][]byte{"total:owner/repo": []byte("42")},
+			pageResult:     []byte("<html>repo page</html>"),
+			expectedStatus: fiber.StatusOK,
+		},
+		{
+			name: "render page with total and svg",
+			url:  "/owner/repo",
+			storeData: map[string][]byte{
+				"total:owner/repo": []byte("42"),
+				"svg:owner/repo":   []byte("<svg/>"),
+			},
+			pageResult:     []byte("<html>repo page</html>"),
+			expectedStatus: fiber.StatusOK,
+		},
+		{
+			name:           "with package id - redirect",
+			url:            "/owner/repo?id=pkg1",
+			expectedStatus: fiber.StatusTemporaryRedirect,
+		},
+		{
+			name:           "with package id - render",
+			url:            "/owner/repo?id=pkg1",
+			storeData:      map[string][]byte{"total:owner/repo:pkg1": []byte("10")},
+			pageResult:     []byte("<html>pkg page</html>"),
+			expectedStatus: fiber.StatusOK,
+		},
+	}
+
+	cfg := test.NewConfig()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := test.NewMockStore()
+			for k, v := range tt.storeData {
+				store.Save(k, v)
+			}
+
+			renderer := &test.MockRenderer{PageResult: tt.pageResult}
+			app := test.NewServer(cfg)
+			h := NewRepoHandler(store, renderer)
+			app.Get("/:owner/:repo", h.RepoPage)
+
+			req := httptest.NewRequest("GET", tt.url, nil)
+			resp, err := app.Test(req, -1)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+		})
+	}
+}
+
 func TestRepoHandler_Formats(t *testing.T) {
 	cfg := test.NewConfig()
-	cfg.DatabasePath = "/tmp/dependents-test-repo-formats"
-	dbService := database.NewBadgerService(cfg.DatabasePath)
-	dbService.Save("total:owner/repo", []byte("42"))
-	dbService.Save("svg:owner/repo", []byte("<svg/>"))
-	dbService.Save("total:owner/repo:pkg1", []byte("7"))
-	defer dbService.Close()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo", []byte("42"))
+	store.Save("svg:owner/repo", []byte("<svg/>"))
+	store.Save("total:owner/repo:pkg1", []byte("7"))
 
 	app := test.NewServer(cfg)
-	h := NewRepoHandler(dbService, render.NewRenderService())
+	h := NewRepoHandler(store, &test.MockRenderer{PageResult: []byte("<html>ok</html>")})
 	app.Get("/:owner/:repo", h.RepoPage)
 
 	t.Run("json", func(t *testing.T) {

--- a/api/internal/handlers/sitemap.go
+++ b/api/internal/handlers/sitemap.go
@@ -4,23 +4,22 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"dependents.info/internal/config"
-	"dependents.info/internal/service/database"
-	"dependents.info/internal/service/render"
+	"dependents.info/internal/service"
 	"dependents.info/pkg/utils"
 )
 
 type SitemapHandler struct {
-	renderService   *render.RenderService
-	databaseService *database.BadgerService
+	renderer service.Renderer
+	store    service.Store
 }
 
 func NewSitemapHandler(
-	dbService *database.BadgerService,
-	renderService *render.RenderService,
+	store service.Store,
+	renderer service.Renderer,
 ) *SitemapHandler {
 	return &SitemapHandler{
-		databaseService: dbService,
-		renderService:   renderService,
+		store:    store,
+		renderer: renderer,
 	}
 }
 
@@ -29,7 +28,7 @@ func (h *SitemapHandler) Sitemap(c *fiber.Ctx) error {
 
 	urls := make([]string, 0)
 	seen := make(map[string]struct{})
-	h.databaseService.IterateKeys(func(key string) {
+	h.store.IterateKeys(func(key string) {
 		route := utils.ToRoute(key)
 		if _, exists := seen[route]; !exists {
 			seen[route] = struct{}{}
@@ -37,7 +36,7 @@ func (h *SitemapHandler) Sitemap(c *fiber.Ctx) error {
 		}
 	})
 
-	sitemapBytes, err := h.renderService.RenderSitemap(urls)
+	sitemapBytes, err := h.renderer.RenderSitemap(urls)
 	if err != nil {
 		return utils.SendError(c, fiber.StatusInternalServerError, "Failed to render sitemap", err)
 	}

--- a/api/internal/handlers/sitemap_test.go
+++ b/api/internal/handlers/sitemap_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"dependents.info/internal/test"
+)
+
+func TestSitemapHandler_Sitemap(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	store.Save("total:owner/repo", []byte("10"))
+	store.Save("svg:owner/repo", []byte("<svg/>"))
+
+	renderer := &test.MockRenderer{
+		SitemapResult: []byte(`<?xml version="1.0"?><urlset><url><loc>http://localhost:5000/owner/repo</loc></url></urlset>`),
+	}
+
+	app := test.NewServer(cfg)
+	h := NewSitemapHandler(store, renderer)
+	app.Get("/sitemap.xml", h.Sitemap)
+
+	req := httptest.NewRequest("GET", "/sitemap.xml", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "owner/repo") {
+		t.Error("expected sitemap to contain owner/repo")
+	}
+}
+
+func TestSitemapHandler_Sitemap_Empty(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	renderer := &test.MockRenderer{SitemapResult: []byte(`<?xml version="1.0"?><urlset></urlset>`)}
+
+	app := test.NewServer(cfg)
+	h := NewSitemapHandler(store, renderer)
+	app.Get("/sitemap.xml", h.Sitemap)
+
+	req := httptest.NewRequest("GET", "/sitemap.xml", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestSitemapHandler_Sitemap_RenderError(t *testing.T) {
+	cfg := test.NewConfig()
+	store := test.NewMockStore()
+	renderer := &test.MockRenderer{SitemapErr: errors.New("template error")}
+
+	app := test.NewServer(cfg)
+	h := NewSitemapHandler(store, renderer)
+	app.Get("/sitemap.xml", h.Sitemap)
+
+	req := httptest.NewRequest("GET", "/sitemap.xml", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}

--- a/api/internal/service/github/dependents.go
+++ b/api/internal/service/github/dependents.go
@@ -1,70 +1,174 @@
 package github
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
+	"time"
 
 	"dependents.info/internal/models"
-	"dependents.info/internal/service/render"
 	"dependents.info/pkg/utils"
 )
 
+type renderer interface {
+	RenderSVG(d models.IngestRequest) ([]byte, error)
+}
+
 type DependentsService struct {
-	renderService *render.RenderService
+	renderer   renderer
+	client     *http.Client
+	fetchPage  func(url string) (string, error)
+	fetchImage func(url string) (string, error)
 }
 
-func NewDependentsService(renderService *render.RenderService) *DependentsService {
-	return &DependentsService{
-		renderService: renderService,
+func NewDependentsService(r renderer) *DependentsService {
+	s := &DependentsService{
+		renderer: r,
+		client:   &http.Client{Timeout: 8 * time.Second},
 	}
+	s.fetchPage = s.defaultFetchPage
+	s.fetchImage = s.defaultFetchImage
+	return s
 }
 
-func (s *DependentsService) NewTask(repo string, id string, kind string, callback func(total int, svg []byte)) {
+func (s *DependentsService) NewTask(repo string, id string, kind string, callback func(total int, svg []byte)) error {
 	url := "https://github.com/" + repo + "/network/dependents"
 	if id != "" {
 		url += "?package_id=" + id
 	}
-	page, err := fetchPage(url)
+	page, err := s.fetchPage(url)
 	if err != nil {
-		return
+		return fmt.Errorf("fetch page: %w", err)
 	}
 	total, err := utils.ParseTotalDependents(page, repo)
 	if err != nil {
-		return
+		return fmt.Errorf("parse total: %w", err)
 	}
 	if kind == "badge" {
 		if callback != nil {
 			callback(total, nil)
 		}
-		return
+		return nil
 	}
-	dependents, err := utils.ParseDependents(page)
+	dependents, err := s.buildDependents(page)
 	if err != nil {
-		return
+		return fmt.Errorf("build dependents: %w", err)
 	}
 	req := models.IngestRequest{
 		Dependents: dependents,
 		Total:      total,
 	}
-	svgBytes, err := s.renderService.RenderSVG(req)
+	svgBytes, err := s.renderer.RenderSVG(req)
 	if err != nil {
-		return
+		return fmt.Errorf("render svg: %w", err)
 	}
 	if callback != nil {
 		callback(total, svgBytes)
 	}
+	return nil
 }
 
-func fetchPage(url string) (string, error) {
-	resp, err := http.Get(url)
+func (s *DependentsService) buildDependents(page string) ([]models.Dependent, error) {
+	nodes, err := utils.ParseDependentNodes(page)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch dependents: %v", err)
+		return nil, err
 	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %v", err)
+
+	type result struct {
+		index int
+		dep   models.Dependent
+		err   error
 	}
-	return string(body), nil
+
+	var wg sync.WaitGroup
+	results := make(chan result, len(nodes))
+
+	for i, node := range nodes {
+		wg.Add(1)
+		go func(idx int, n utils.DependentInfo) {
+			defer wg.Done()
+			image, err := s.fetchImage(n.ImageURL)
+			results <- result{
+				index: idx,
+				dep:   models.Dependent{Image: image, Stars: n.Stars, Owner: n.Owner},
+				err:   err,
+			}
+		}(i, node)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	byIndex := make([]models.Dependent, len(nodes))
+	ok := make([]bool, len(nodes))
+	for r := range results {
+		if r.err == nil {
+			byIndex[r.index] = r.dep
+			ok[r.index] = true
+		}
+	}
+
+	dependents := make([]models.Dependent, 0, len(nodes))
+	for i, d := range byIndex {
+		if ok[i] {
+			dependents = append(dependents, d)
+		}
+	}
+	return dependents, nil
+}
+
+func (s *DependentsService) defaultFetchPage(url string) (string, error) {
+	var body string
+	err := utils.RetryWithBackoff(3, 500*time.Millisecond, func() error {
+		resp, err := s.client.Get(url)
+		if err != nil {
+			return fmt.Errorf("failed to fetch page: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 500 {
+			return fmt.Errorf("server error: status %d", resp.StatusCode)
+		}
+		if resp.StatusCode != http.StatusOK {
+			io.Copy(io.Discard, resp.Body)
+			return utils.PermanentError{Err: fmt.Errorf("unexpected status %d", resp.StatusCode)}
+		}
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read body: %w", err)
+		}
+		body = string(data)
+		return nil
+	})
+	return body, err
+}
+
+func (s *DependentsService) defaultFetchImage(url string) (string, error) {
+	var dataURI string
+	err := utils.RetryWithBackoff(3, 300*time.Millisecond, func() error {
+		resp, err := s.client.Get(url)
+		if err != nil {
+			return fmt.Errorf("failed to fetch image: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 500 {
+			return fmt.Errorf("server error: status %d", resp.StatusCode)
+		}
+		if resp.StatusCode != http.StatusOK {
+			io.Copy(io.Discard, resp.Body)
+			return utils.PermanentError{Err: fmt.Errorf("unexpected status %d", resp.StatusCode)}
+		}
+		imageData, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read image data: %w", err)
+		}
+		base64Str := base64.StdEncoding.EncodeToString(imageData)
+		mimeType := resp.Header.Get("Content-Type")
+		dataURI = fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
+		return nil
+	})
+	return dataURI, err
 }

--- a/api/internal/service/github/dependents.go
+++ b/api/internal/service/github/dependents.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -19,8 +20,8 @@ type renderer interface {
 type DependentsService struct {
 	renderer   renderer
 	client     *http.Client
-	fetchPage  func(url string) (string, error)
-	fetchImage func(url string) (string, error)
+	fetchPage  func(ctx context.Context, url string) (string, error)
+	fetchImage func(ctx context.Context, url string) (string, error)
 }
 
 func NewDependentsService(r renderer) *DependentsService {
@@ -33,12 +34,18 @@ func NewDependentsService(r renderer) *DependentsService {
 	return s
 }
 
-func (s *DependentsService) NewTask(repo string, id string, kind string, callback func(total int, svg []byte)) error {
+func (s *DependentsService) NewTask(ctx context.Context, repo string, id string, kind string, callback func(total int, svg []byte)) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
 	url := "https://github.com/" + repo + "/network/dependents"
 	if id != "" {
 		url += "?package_id=" + id
 	}
-	page, err := s.fetchPage(url)
+	page, err := s.fetchPage(ctx, url)
 	if err != nil {
 		return fmt.Errorf("fetch page: %w", err)
 	}
@@ -52,7 +59,7 @@ func (s *DependentsService) NewTask(repo string, id string, kind string, callbac
 		}
 		return nil
 	}
-	dependents, err := s.buildDependents(page)
+	dependents, err := s.buildDependents(ctx, page)
 	if err != nil {
 		return fmt.Errorf("build dependents: %w", err)
 	}
@@ -70,7 +77,7 @@ func (s *DependentsService) NewTask(repo string, id string, kind string, callbac
 	return nil
 }
 
-func (s *DependentsService) buildDependents(page string) ([]models.Dependent, error) {
+func (s *DependentsService) buildDependents(ctx context.Context, page string) ([]models.Dependent, error) {
 	nodes, err := utils.ParseDependentNodes(page)
 	if err != nil {
 		return nil, err
@@ -89,7 +96,7 @@ func (s *DependentsService) buildDependents(page string) ([]models.Dependent, er
 		wg.Add(1)
 		go func(idx int, n utils.DependentInfo) {
 			defer wg.Done()
-			image, err := s.fetchImage(n.ImageURL)
+			image, err := s.fetchImage(ctx, n.ImageURL)
 			results <- result{
 				index: idx,
 				dep:   models.Dependent{Image: image, Stars: n.Stars, Owner: n.Owner},
@@ -112,24 +119,37 @@ func (s *DependentsService) buildDependents(page string) ([]models.Dependent, er
 		}
 	}
 
-	dependents := make([]models.Dependent, 0, len(nodes))
+	dependents := make([]models.Dependent, 0, 11)
 	for i, d := range byIndex {
-		if ok[i] {
-			dependents = append(dependents, d)
+		if !ok[i] {
+			continue
+		}
+		dependents = append(dependents, d)
+		if len(dependents) == 11 {
+			break
 		}
 	}
 	return dependents, nil
 }
 
-func (s *DependentsService) defaultFetchPage(url string) (string, error) {
+func retryableStatus(code int) bool {
+	return code >= 500 || code == http.StatusTooManyRequests
+}
+
+func (s *DependentsService) defaultFetchPage(ctx context.Context, url string) (string, error) {
 	var body string
-	err := utils.RetryWithBackoff(3, 500*time.Millisecond, func() error {
-		resp, err := s.client.Get(url)
+	err := utils.RetryWithBackoff(ctx, 3, 500*time.Millisecond, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := s.client.Do(req)
 		if err != nil {
 			return fmt.Errorf("failed to fetch page: %w", err)
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode >= 500 {
+		if retryableStatus(resp.StatusCode) {
+			io.Copy(io.Discard, resp.Body)
 			return fmt.Errorf("server error: status %d", resp.StatusCode)
 		}
 		if resp.StatusCode != http.StatusOK {
@@ -146,15 +166,20 @@ func (s *DependentsService) defaultFetchPage(url string) (string, error) {
 	return body, err
 }
 
-func (s *DependentsService) defaultFetchImage(url string) (string, error) {
+func (s *DependentsService) defaultFetchImage(ctx context.Context, url string) (string, error) {
 	var dataURI string
-	err := utils.RetryWithBackoff(3, 300*time.Millisecond, func() error {
-		resp, err := s.client.Get(url)
+	err := utils.RetryWithBackoff(ctx, 3, 300*time.Millisecond, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := s.client.Do(req)
 		if err != nil {
 			return fmt.Errorf("failed to fetch image: %w", err)
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode >= 500 {
+		if retryableStatus(resp.StatusCode) {
+			io.Copy(io.Discard, resp.Body)
 			return fmt.Errorf("server error: status %d", resp.StatusCode)
 		}
 		if resp.StatusCode != http.StatusOK {

--- a/api/internal/service/github/dependents_test.go
+++ b/api/internal/service/github/dependents_test.go
@@ -1,8 +1,14 @@
 package github
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"dependents.info/internal/models"
@@ -35,12 +41,12 @@ func dependentsPageHTML(repo string) string {
 
 func TestNewTask_Badge(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		return dependentsPageHTML("owner/repo"), nil
 	}
 
 	var gotTotal int
-	err := svc.NewTask("owner/repo", "", "badge", func(total int, svg []byte) {
+	err := svc.NewTask(context.Background(), "owner/repo", "", "badge", func(total int, svg []byte) {
 		gotTotal = total
 	})
 	if err != nil {
@@ -53,16 +59,16 @@ func TestNewTask_Badge(t *testing.T) {
 
 func TestNewTask_Image(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{result: []byte("<svg>rendered</svg>")})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		return dependentsPageHTML("owner/repo"), nil
 	}
-	svc.fetchImage = func(url string) (string, error) {
+	svc.fetchImage = func(_ context.Context, url string) (string, error) {
 		return "data:image/png;base64,abc=", nil
 	}
 
 	var gotTotal int
 	var gotSVG []byte
-	err := svc.NewTask("owner/repo", "", "image", func(total int, svg []byte) {
+	err := svc.NewTask(context.Background(), "owner/repo", "", "image", func(total int, svg []byte) {
 		gotTotal = total
 		gotSVG = svg
 	})
@@ -79,11 +85,11 @@ func TestNewTask_Image(t *testing.T) {
 
 func TestNewTask_FetchPageError(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		return "", errors.New("network error")
 	}
 
-	err := svc.NewTask("owner/repo", "", "badge", nil)
+	err := svc.NewTask(context.Background(), "owner/repo", "", "badge", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -91,14 +97,14 @@ func TestNewTask_FetchPageError(t *testing.T) {
 
 func TestNewTask_RenderError(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{err: errors.New("render failed")})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		return dependentsPageHTML("owner/repo"), nil
 	}
-	svc.fetchImage = func(url string) (string, error) {
+	svc.fetchImage = func(_ context.Context, url string) (string, error) {
 		return "data:image/png;base64,abc=", nil
 	}
 
-	err := svc.NewTask("owner/repo", "", "image", nil)
+	err := svc.NewTask(context.Background(), "owner/repo", "", "image", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -107,12 +113,12 @@ func TestNewTask_RenderError(t *testing.T) {
 func TestNewTask_WithPackageId(t *testing.T) {
 	var capturedURL string
 	svc := NewDependentsService(&stubRenderer{})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		capturedURL = url
 		return dependentsPageHTML("owner/repo"), nil
 	}
 
-	if err := svc.NewTask("owner/repo", "pkg123", "badge", func(int, []byte) {}); err != nil {
+	if err := svc.NewTask(context.Background(), "owner/repo", "pkg123", "badge", func(int, []byte) {}); err != nil {
 		t.Fatalf("NewTask() error = %v", err)
 	}
 	expected := "https://github.com/owner/repo/network/dependents?package_id=pkg123"
@@ -123,15 +129,15 @@ func TestNewTask_WithPackageId(t *testing.T) {
 
 func TestNewTask_ImageFetchError_SkipsDependent(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{result: []byte("<svg/>")})
-	svc.fetchPage = func(url string) (string, error) {
+	svc.fetchPage = func(_ context.Context, url string) (string, error) {
 		return dependentsPageHTML("owner/repo"), nil
 	}
-	svc.fetchImage = func(url string) (string, error) {
+	svc.fetchImage = func(_ context.Context, url string) (string, error) {
 		return "", errors.New("image fetch failed")
 	}
 
 	var gotSVG []byte
-	err := svc.NewTask("owner/repo", "", "image", func(total int, svg []byte) {
+	err := svc.NewTask(context.Background(), "owner/repo", "", "image", func(total int, svg []byte) {
 		gotSVG = svg
 	})
 	if err != nil {
@@ -144,10 +150,10 @@ func TestNewTask_ImageFetchError_SkipsDependent(t *testing.T) {
 
 func TestBuildDependents_Parallel(t *testing.T) {
 	svc := NewDependentsService(&stubRenderer{})
-	callCount := 0
-	svc.fetchImage = func(url string) (string, error) {
-		callCount++
-		return fmt.Sprintf("data:image/png;base64,%d", callCount), nil
+	var callCount atomic.Int32
+	svc.fetchImage = func(_ context.Context, url string) (string, error) {
+		callCount.Add(1)
+		return "data:image/png;base64," + url, nil
 	}
 
 	html := `<html><body>
@@ -163,7 +169,7 @@ func TestBuildDependents_Parallel(t *testing.T) {
 		</div>
 	</body></html>`
 
-	deps, err := svc.buildDependents(html)
+	deps, err := svc.buildDependents(context.Background(), html)
 	if err != nil {
 		t.Fatalf("buildDependents() error = %v", err)
 	}
@@ -173,7 +179,73 @@ func TestBuildDependents_Parallel(t *testing.T) {
 	if deps[0].Owner != "user2" || deps[1].Owner != "user1" || deps[2].Owner != "user3" {
 		t.Errorf("expected star order user2, user1, user3; got %s, %s, %s", deps[0].Owner, deps[1].Owner, deps[2].Owner)
 	}
-	if callCount != 3 {
-		t.Errorf("expected 3 image fetches, got %d", callCount)
+	if !strings.Contains(deps[0].Image, "https://example.com/2.png") ||
+		!strings.Contains(deps[1].Image, "https://example.com/1.png") ||
+		!strings.Contains(deps[2].Image, "https://example.com/3.png") {
+		t.Errorf("images not aligned with owners: %q %q %q", deps[0].Image, deps[1].Image, deps[2].Image)
+	}
+	if callCount.Load() != 3 {
+		t.Errorf("expected 3 image fetches, got %d", callCount.Load())
+	}
+}
+
+func TestBuildDependents_BackfillsFailedAvatars(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{})
+	svc.fetchImage = func(_ context.Context, url string) (string, error) {
+		if strings.Contains(url, "/11.png") {
+			return "", errors.New("flaky")
+		}
+		return "data:image/png;base64," + url, nil
+	}
+
+	var html strings.Builder
+	html.WriteString(`<html><body>`)
+	for i := range 12 {
+		fmt.Fprintf(&html, `<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">user%d</a>
+			<img src="https://example.com/%d.png"/>
+			<span class="octicon-star"></span> %d
+		</div>`, i, i, i)
+	}
+	html.WriteString(`</body></html>`)
+
+	deps, err := svc.buildDependents(context.Background(), html.String())
+	if err != nil {
+		t.Fatalf("buildDependents() error = %v", err)
+	}
+	if len(deps) != 11 {
+		t.Fatalf("expected 11 dependents, got %d", len(deps))
+	}
+	if deps[0].Owner != "user10" {
+		t.Errorf("expected highest remaining star owner user10, got %s", deps[0].Owner)
+	}
+	for _, d := range deps {
+		if d.Owner == "user11" || strings.Contains(d.Image, "/11.png") {
+			t.Fatalf("failed avatar should be skipped, got %+v", d)
+		}
+	}
+}
+
+func TestDefaultFetchPage_Retries429(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		io.WriteString(w, "ok")
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := NewDependentsService(&stubRenderer{})
+	body, err := svc.defaultFetchPage(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("defaultFetchPage() error = %v", err)
+	}
+	if body != "ok" {
+		t.Errorf("body = %q", body)
+	}
+	if hits.Load() != 2 {
+		t.Errorf("expected 2 hits, got %d", hits.Load())
 	}
 }

--- a/api/internal/service/github/dependents_test.go
+++ b/api/internal/service/github/dependents_test.go
@@ -1,0 +1,179 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"dependents.info/internal/models"
+)
+
+type stubRenderer struct {
+	result []byte
+	err    error
+}
+
+func (s *stubRenderer) RenderSVG(_ models.IngestRequest) ([]byte, error) {
+	return s.result, s.err
+}
+
+func dependentsPageHTML(repo string) string {
+	return fmt.Sprintf(`<html><body>
+		<div role="status" class="table-list-header-toggle states flex-auto pl-0">
+			<a href="/%s/network/dependents?dependent_type=REPOSITORY">
+				100 Repositories
+			</a>
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">testowner</a>
+			<img src="https://avatars.githubusercontent.com/u/1?v=4" />
+			<span class="octicon-star"></span>
+			42
+		</div>
+	</body></html>`, repo)
+}
+
+func TestNewTask_Badge(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{})
+	svc.fetchPage = func(url string) (string, error) {
+		return dependentsPageHTML("owner/repo"), nil
+	}
+
+	var gotTotal int
+	err := svc.NewTask("owner/repo", "", "badge", func(total int, svg []byte) {
+		gotTotal = total
+	})
+	if err != nil {
+		t.Fatalf("NewTask() error = %v", err)
+	}
+	if gotTotal != 100 {
+		t.Errorf("expected total 100, got %d", gotTotal)
+	}
+}
+
+func TestNewTask_Image(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{result: []byte("<svg>rendered</svg>")})
+	svc.fetchPage = func(url string) (string, error) {
+		return dependentsPageHTML("owner/repo"), nil
+	}
+	svc.fetchImage = func(url string) (string, error) {
+		return "data:image/png;base64,abc=", nil
+	}
+
+	var gotTotal int
+	var gotSVG []byte
+	err := svc.NewTask("owner/repo", "", "image", func(total int, svg []byte) {
+		gotTotal = total
+		gotSVG = svg
+	})
+	if err != nil {
+		t.Fatalf("NewTask() error = %v", err)
+	}
+	if gotTotal != 100 {
+		t.Errorf("expected total 100, got %d", gotTotal)
+	}
+	if string(gotSVG) != "<svg>rendered</svg>" {
+		t.Errorf("expected rendered SVG, got %q", string(gotSVG))
+	}
+}
+
+func TestNewTask_FetchPageError(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{})
+	svc.fetchPage = func(url string) (string, error) {
+		return "", errors.New("network error")
+	}
+
+	err := svc.NewTask("owner/repo", "", "badge", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestNewTask_RenderError(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{err: errors.New("render failed")})
+	svc.fetchPage = func(url string) (string, error) {
+		return dependentsPageHTML("owner/repo"), nil
+	}
+	svc.fetchImage = func(url string) (string, error) {
+		return "data:image/png;base64,abc=", nil
+	}
+
+	err := svc.NewTask("owner/repo", "", "image", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestNewTask_WithPackageId(t *testing.T) {
+	var capturedURL string
+	svc := NewDependentsService(&stubRenderer{})
+	svc.fetchPage = func(url string) (string, error) {
+		capturedURL = url
+		return dependentsPageHTML("owner/repo"), nil
+	}
+
+	if err := svc.NewTask("owner/repo", "pkg123", "badge", func(int, []byte) {}); err != nil {
+		t.Fatalf("NewTask() error = %v", err)
+	}
+	expected := "https://github.com/owner/repo/network/dependents?package_id=pkg123"
+	if capturedURL != expected {
+		t.Errorf("expected URL %q, got %q", expected, capturedURL)
+	}
+}
+
+func TestNewTask_ImageFetchError_SkipsDependent(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{result: []byte("<svg/>")})
+	svc.fetchPage = func(url string) (string, error) {
+		return dependentsPageHTML("owner/repo"), nil
+	}
+	svc.fetchImage = func(url string) (string, error) {
+		return "", errors.New("image fetch failed")
+	}
+
+	var gotSVG []byte
+	err := svc.NewTask("owner/repo", "", "image", func(total int, svg []byte) {
+		gotSVG = svg
+	})
+	if err != nil {
+		t.Fatalf("NewTask() error = %v", err)
+	}
+	if string(gotSVG) != "<svg/>" {
+		t.Errorf("expected rendered SVG even with failed images, got %q", string(gotSVG))
+	}
+}
+
+func TestBuildDependents_Parallel(t *testing.T) {
+	svc := NewDependentsService(&stubRenderer{})
+	callCount := 0
+	svc.fetchImage = func(url string) (string, error) {
+		callCount++
+		return fmt.Sprintf("data:image/png;base64,%d", callCount), nil
+	}
+
+	html := `<html><body>
+		<div role="status"><a href="/o/r/network/dependents?dependent_type=REPOSITORY">10 Repositories</a></div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">user1</a><img src="https://example.com/1.png"/><span class="octicon-star"></span> 10
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">user2</a><img src="https://example.com/2.png"/><span class="octicon-star"></span> 20
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">user3</a><img src="https://example.com/3.png"/><span class="octicon-star"></span> 5
+		</div>
+	</body></html>`
+
+	deps, err := svc.buildDependents(html)
+	if err != nil {
+		t.Fatalf("buildDependents() error = %v", err)
+	}
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 dependents, got %d", len(deps))
+	}
+	if deps[0].Owner != "user2" || deps[1].Owner != "user1" || deps[2].Owner != "user3" {
+		t.Errorf("expected star order user2, user1, user3; got %s, %s, %s", deps[0].Owner, deps[1].Owner, deps[2].Owner)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 image fetches, got %d", callCount)
+	}
+}

--- a/api/internal/service/services.go
+++ b/api/internal/service/services.go
@@ -1,17 +1,45 @@
 package service
 
 import (
+	"context"
+	"time"
+
 	"dependents.info/internal/config"
+	"dependents.info/internal/models"
 	"dependents.info/internal/service/database"
 	"dependents.info/internal/service/github"
 	"dependents.info/internal/service/render"
 )
 
+type Store interface {
+	Get(key string, out *string) error
+	Save(key string, data []byte) error
+	SaveWithTTL(key string, data []byte, ttl time.Duration) error
+	Delete(key string) error
+	IterateKeys(callback func(key string))
+	Close() error
+	Sync() error
+}
+
+type Renderer interface {
+	RenderSVG(d models.IngestRequest) ([]byte, error)
+	RenderPage(d models.RepoPage) ([]byte, error)
+	RenderSitemap(data []string) ([]byte, error)
+}
+
+type OIDCVerifier interface {
+	VerifyToken(ctx context.Context, rawToken string, expectedRepo string) error
+}
+
+type DependentsTasker interface {
+	NewTask(repo string, id string, kind string, callback func(total int, svg []byte)) error
+}
+
 type Services struct {
-	GitHubOIDCService *github.OIDCService
-	DependentsService *github.DependentsService
-	DatabaseService   *database.BadgerService
-	RenderService     *render.RenderService
+	OIDCVerifier      OIDCVerifier
+	DependentsService DependentsTasker
+	Store             Store
+	Renderer          Renderer
 }
 
 func BuildAll(cfg *config.Config) *Services {
@@ -21,9 +49,9 @@ func BuildAll(cfg *config.Config) *Services {
 	dependentsService := github.NewDependentsService(imageService)
 
 	return &Services{
-		GitHubOIDCService: oidcService,
-		DatabaseService:   dbService,
-		RenderService:     imageService,
+		OIDCVerifier:      oidcService,
+		Store:             dbService,
+		Renderer:          imageService,
 		DependentsService: dependentsService,
 	}
 }

--- a/api/internal/service/services.go
+++ b/api/internal/service/services.go
@@ -32,7 +32,7 @@ type OIDCVerifier interface {
 }
 
 type DependentsTasker interface {
-	NewTask(repo string, id string, kind string, callback func(total int, svg []byte)) error
+	NewTask(ctx context.Context, repo string, id string, kind string, callback func(total int, svg []byte)) error
 }
 
 type Services struct {

--- a/api/internal/test/mocks.go
+++ b/api/internal/test/mocks.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"dependents.info/internal/models"
+)
+
+var ErrNotFound = errors.New("key not found")
+
+type MockStore struct {
+	mu   sync.RWMutex
+	Data map[string][]byte
+}
+
+func NewMockStore() *MockStore {
+	return &MockStore{Data: make(map[string][]byte)}
+}
+
+func (m *MockStore) Get(key string, out *string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.Data[key]
+	if !ok {
+		return ErrNotFound
+	}
+	*out = string(v)
+	return nil
+}
+
+func (m *MockStore) Save(key string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Data[key] = data
+	return nil
+}
+
+func (m *MockStore) SaveWithTTL(key string, data []byte, _ time.Duration) error {
+	return m.Save(key, data)
+}
+
+func (m *MockStore) Delete(key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Data, key)
+	return nil
+}
+
+func (m *MockStore) IterateKeys(callback func(key string)) {
+	m.mu.RLock()
+	keys := make([]string, 0, len(m.Data))
+	for k := range m.Data {
+		keys = append(keys, k)
+	}
+	m.mu.RUnlock()
+	for _, k := range keys {
+		callback(k)
+	}
+}
+
+func (m *MockStore) Close() error { return nil }
+func (m *MockStore) Sync() error  { return nil }
+
+type MockRenderer struct {
+	SVGResult     []byte
+	SVGErr        error
+	PageResult    []byte
+	PageErr       error
+	SitemapResult []byte
+	SitemapErr    error
+}
+
+func (m *MockRenderer) RenderSVG(_ models.IngestRequest) ([]byte, error) {
+	return m.SVGResult, m.SVGErr
+}
+
+func (m *MockRenderer) RenderPage(_ models.RepoPage) ([]byte, error) {
+	return m.PageResult, m.PageErr
+}
+
+func (m *MockRenderer) RenderSitemap(_ []string) ([]byte, error) {
+	return m.SitemapResult, m.SitemapErr
+}
+
+type MockDependentsTasker struct {
+	NewTaskFn func(repo, id, kind string, callback func(int, []byte)) error
+}
+
+func (m *MockDependentsTasker) NewTask(repo, id, kind string, callback func(int, []byte)) error {
+	if m.NewTaskFn != nil {
+		return m.NewTaskFn(repo, id, kind, callback)
+	}
+	return nil
+}
+
+type MockOIDCVerifier struct {
+	Err error
+}
+
+func (m *MockOIDCVerifier) VerifyToken(_ context.Context, _ string, _ string) error {
+	return m.Err
+}

--- a/api/internal/test/mocks.go
+++ b/api/internal/test/mocks.go
@@ -86,12 +86,12 @@ func (m *MockRenderer) RenderSitemap(_ []string) ([]byte, error) {
 }
 
 type MockDependentsTasker struct {
-	NewTaskFn func(repo, id, kind string, callback func(int, []byte)) error
+	NewTaskFn func(ctx context.Context, repo, id, kind string, callback func(int, []byte)) error
 }
 
-func (m *MockDependentsTasker) NewTask(repo, id, kind string, callback func(int, []byte)) error {
+func (m *MockDependentsTasker) NewTask(ctx context.Context, repo, id, kind string, callback func(int, []byte)) error {
 	if m.NewTaskFn != nil {
-		return m.NewTaskFn(repo, id, kind, callback)
+		return m.NewTaskFn(ctx, repo, id, kind, callback)
 	}
 	return nil
 }

--- a/api/main.go
+++ b/api/main.go
@@ -40,6 +40,6 @@ func main() {
 		log.Panic(err)
 	}
 
-	services.DatabaseService.Sync()
-	services.DatabaseService.Close()
+	services.Store.Sync()
+	services.Store.Close()
 }

--- a/api/pkg/utils/fns.go
+++ b/api/pkg/utils/fns.go
@@ -2,11 +2,8 @@ package utils
 
 import (
 	"embed"
-	"encoding/base64"
 	"fmt"
-	"io"
 	"math"
-	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -14,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"dependents.info/internal/models"
 	"github.com/andybalholm/cascadia"
 	"github.com/gofiber/fiber/v2"
 	"golang.org/x/net/html"
@@ -141,7 +137,13 @@ func ParseTotalDependents(doc string, repo string) (int, error) {
 	return number, nil
 }
 
-func ParseDependents(doc string) ([]models.Dependent, error) {
+type DependentInfo struct {
+	Owner    string
+	Stars    int
+	ImageURL string
+}
+
+func ParseDependentNodes(doc string) ([]DependentInfo, error) {
 	node, err := html.Parse(strings.NewReader(doc))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse HTML: %w", err)
@@ -151,46 +153,41 @@ func ParseDependents(doc string) ([]models.Dependent, error) {
 	dependentSel, _ := cascadia.Compile(`[data-test-id="dg-repo-pkg-dependent"]`)
 	ownerSel, _ := cascadia.Compile(`[data-hovercard-type="user"], [data-hovercard-type="organization"]`)
 	nodes := cascadia.QueryAll(node, dependentSel)
-	dependents := make([]models.Dependent, 0, 30)
-	exists := func(parsedOwner string) bool {
-		for _, d := range dependents {
-			if d.Owner == parsedOwner {
-				return true
-			}
-		}
-		return false
-	}
+	seen := make(map[string]struct{})
+	result := make([]DependentInfo, 0, 30)
 	for _, el := range nodes {
-		var image string
 		imgNode := cascadia.Query(el, imgSel)
 		starsNode := cascadia.Query(el, starsSel)
 		ownerNode := cascadia.Query(el, ownerSel)
+		if ownerNode == nil || ownerNode.FirstChild == nil {
+			continue
+		}
 		parsedOwner := ownerNode.FirstChild.Data
-		if exists(parsedOwner) {
+		if _, ok := seen[parsedOwner]; ok {
 			continue
 		}
-		image, err = imageNodeToUrl(imgNode)
+		seen[parsedOwner] = struct{}{}
+		imageURL, err := imageNodeToUrl(imgNode)
 		if err != nil {
 			continue
 		}
-		image, err = imageUrlToBase64(image)
-		if err != nil {
+		if starsNode == nil || starsNode.Parent == nil {
 			continue
 		}
 		stars, _ := extractNumber(starsNode.Parent)
-		dependents = append(dependents, models.Dependent{
-			Image: image,
-			Stars: stars,
-			Owner: parsedOwner,
+		result = append(result, DependentInfo{
+			Owner:    parsedOwner,
+			Stars:    stars,
+			ImageURL: imageURL,
 		})
 	}
-	sort.Slice(dependents, func(i, j int) bool {
-		return dependents[i].Stars > dependents[j].Stars
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Stars > result[j].Stars
 	})
-	if len(dependents) > 11 {
-		return dependents[:11], nil
+	if len(result) > 11 {
+		return result[:11], nil
 	}
-	return dependents, nil
+	return result, nil
 }
 
 func extractNumber(anchor *html.Node) (int, error) {
@@ -220,20 +217,4 @@ func imageNodeToUrl(n *html.Node) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no src attribute found in image node")
-}
-
-func imageUrlToBase64(url string) (string, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", fmt.Errorf("error fetching image: %w", err)
-	}
-	defer resp.Body.Close()
-	imageData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("error reading image data: %w", err)
-	}
-	base64Str := base64.StdEncoding.EncodeToString(imageData)
-	mimeType := resp.Header.Get("Content-Type")
-	dataURI := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
-	return dataURI, nil
 }

--- a/api/pkg/utils/fns.go
+++ b/api/pkg/utils/fns.go
@@ -166,7 +166,6 @@ func ParseDependentNodes(doc string) ([]DependentInfo, error) {
 		if _, ok := seen[parsedOwner]; ok {
 			continue
 		}
-		seen[parsedOwner] = struct{}{}
 		imageURL, err := imageNodeToUrl(imgNode)
 		if err != nil {
 			continue
@@ -175,6 +174,7 @@ func ParseDependentNodes(doc string) ([]DependentInfo, error) {
 			continue
 		}
 		stars, _ := extractNumber(starsNode.Parent)
+		seen[parsedOwner] = struct{}{}
 		result = append(result, DependentInfo{
 			Owner:    parsedOwner,
 			Stars:    stars,
@@ -184,9 +184,6 @@ func ParseDependentNodes(doc string) ([]DependentInfo, error) {
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Stars > result[j].Stars
 	})
-	if len(result) > 11 {
-		return result[:11], nil
-	}
 	return result, nil
 }
 

--- a/api/pkg/utils/fns_test.go
+++ b/api/pkg/utils/fns_test.go
@@ -313,7 +313,7 @@ func TestParseDependentNodes_EmptyHTML(t *testing.T) {
 	}
 }
 
-func TestParseDependentNodes_LimitsTo11(t *testing.T) {
+func TestParseDependentNodes_KeepsAllOnPage(t *testing.T) {
 	var html string
 	html = `<html><body>`
 	for i := range 15 {
@@ -329,8 +329,30 @@ func TestParseDependentNodes_LimitsTo11(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseDependentNodes() error = %v", err)
 	}
-	if len(nodes) != 11 {
-		t.Errorf("expected max 11 nodes, got %d", len(nodes))
+	if len(nodes) != 15 {
+		t.Errorf("expected 15 nodes, got %d", len(nodes))
+	}
+}
+
+func TestParseDependentNodes_BrokenFirstCardKeepsLaterSameOwner(t *testing.T) {
+	doc := `<html><body>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userA</a>
+			<span class="octicon-star"></span> 10
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userA</a>
+			<img src="https://example.com/a.png" />
+			<span class="octicon-star"></span> 20
+		</div>
+	</body></html>`
+
+	nodes, err := ParseDependentNodes(doc)
+	if err != nil {
+		t.Fatalf("ParseDependentNodes() error = %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Owner != "userA" || nodes[0].Stars != 20 {
+		t.Fatalf("expected userA with 20 stars, got %+v", nodes)
 	}
 }
 

--- a/api/pkg/utils/fns_test.go
+++ b/api/pkg/utils/fns_test.go
@@ -235,6 +235,105 @@ func TestExtractBearerToken(t *testing.T) {
 	}
 }
 
+func TestParseDependentNodes(t *testing.T) {
+	doc := `<html><body>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userA</a>
+			<img src="https://example.com/a.png" />
+			<span class="octicon-star"></span> 50
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="organization">orgB</a>
+			<img src="https://example.com/b.png" />
+			<span class="octicon-star"></span> 100
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userA</a>
+			<img src="https://example.com/a2.png" />
+			<span class="octicon-star"></span> 30
+		</div>
+	</body></html>`
+
+	nodes, err := ParseDependentNodes(doc)
+	if err != nil {
+		t.Fatalf("ParseDependentNodes() error = %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 unique nodes, got %d", len(nodes))
+	}
+	if nodes[0].Owner != "orgB" {
+		t.Errorf("expected first node owner 'orgB' (highest stars), got %q", nodes[0].Owner)
+	}
+	if nodes[0].Stars != 100 {
+		t.Errorf("expected first node stars 100, got %d", nodes[0].Stars)
+	}
+	if nodes[1].Owner != "userA" {
+		t.Errorf("expected second node owner 'userA', got %q", nodes[1].Owner)
+	}
+	for _, n := range nodes {
+		if n.ImageURL == "" {
+			t.Errorf("expected non-empty ImageURL for %s", n.Owner)
+		}
+	}
+}
+
+func TestParseDependentNodes_SkipsMalformed(t *testing.T) {
+	doc := `<html><body>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<img src="https://example.com/a.png" />
+			<span class="octicon-star"></span> 10
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userA</a>
+			<img src="https://example.com/a.png" />
+		</div>
+		<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">userB</a>
+			<img src="https://example.com/b.png" />
+			<span class="octicon-star"></span> 20
+		</div>
+	</body></html>`
+
+	nodes, err := ParseDependentNodes(doc)
+	if err != nil {
+		t.Fatalf("ParseDependentNodes() error = %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Owner != "userB" {
+		t.Fatalf("expected only userB, got %+v", nodes)
+	}
+}
+
+func TestParseDependentNodes_EmptyHTML(t *testing.T) {
+	nodes, err := ParseDependentNodes("<html><body></body></html>")
+	if err != nil {
+		t.Fatalf("ParseDependentNodes() error = %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(nodes))
+	}
+}
+
+func TestParseDependentNodes_LimitsTo11(t *testing.T) {
+	var html string
+	html = `<html><body>`
+	for i := range 15 {
+		html += `<div data-test-id="dg-repo-pkg-dependent">
+			<a data-hovercard-type="user">user` + strconv.Itoa(i) + `</a>
+			<img src="https://example.com/` + strconv.Itoa(i) + `.png" />
+			<span class="octicon-star"></span> ` + strconv.Itoa(i*10) + `
+		</div>`
+	}
+	html += `</body></html>`
+
+	nodes, err := ParseDependentNodes(html)
+	if err != nil {
+		t.Fatalf("ParseDependentNodes() error = %v", err)
+	}
+	if len(nodes) != 11 {
+		t.Errorf("expected max 11 nodes, got %d", len(nodes))
+	}
+}
+
 func TestParseTotalDependents(t *testing.T) {
 	html := `
 		<div role="status" class="table-list-header-toggle states flex-auto pl-0">

--- a/api/pkg/utils/retry.go
+++ b/api/pkg/utils/retry.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"math/rand/v2"
 	"time"
@@ -13,9 +14,15 @@ type PermanentError struct {
 func (e PermanentError) Error() string { return e.Err.Error() }
 func (e PermanentError) Unwrap() error { return e.Err }
 
-func RetryWithBackoff(maxRetries int, base time.Duration, fn func() error) error {
+func RetryWithBackoff(ctx context.Context, maxRetries int, base time.Duration, fn func() error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
 	for attempt := range maxRetries + 1 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		lastErr = fn()
 		if lastErr == nil {
 			return nil
@@ -27,7 +34,11 @@ func RetryWithBackoff(maxRetries int, base time.Duration, fn func() error) error
 		if attempt < maxRetries {
 			backoff := base * time.Duration(1<<uint(attempt))
 			jitter := time.Duration(rand.Int64N(int64(backoff/2) + 1))
-			time.Sleep(backoff + jitter)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff + jitter):
+			}
 		}
 	}
 	return lastErr

--- a/api/pkg/utils/retry.go
+++ b/api/pkg/utils/retry.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"errors"
+	"math/rand/v2"
+	"time"
+)
+
+type PermanentError struct {
+	Err error
+}
+
+func (e PermanentError) Error() string { return e.Err.Error() }
+func (e PermanentError) Unwrap() error { return e.Err }
+
+func RetryWithBackoff(maxRetries int, base time.Duration, fn func() error) error {
+	var lastErr error
+	for attempt := range maxRetries + 1 {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		var perm PermanentError
+		if errors.As(lastErr, &perm) {
+			return lastErr
+		}
+		if attempt < maxRetries {
+			backoff := base * time.Duration(1<<uint(attempt))
+			jitter := time.Duration(rand.Int64N(int64(backoff/2) + 1))
+			time.Sleep(backoff + jitter)
+		}
+	}
+	return lastErr
+}

--- a/api/pkg/utils/retry_test.go
+++ b/api/pkg/utils/retry_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -8,7 +9,7 @@ import (
 
 func TestRetryWithBackoff_SuccessFirst(t *testing.T) {
 	calls := 0
-	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+	err := RetryWithBackoff(context.Background(), 3, 10*time.Millisecond, func() error {
 		calls++
 		return nil
 	})
@@ -22,7 +23,7 @@ func TestRetryWithBackoff_SuccessFirst(t *testing.T) {
 
 func TestRetryWithBackoff_SuccessAfterRetries(t *testing.T) {
 	calls := 0
-	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+	err := RetryWithBackoff(context.Background(), 3, 10*time.Millisecond, func() error {
 		calls++
 		if calls < 3 {
 			return errors.New("transient")
@@ -40,7 +41,7 @@ func TestRetryWithBackoff_SuccessAfterRetries(t *testing.T) {
 func TestRetryWithBackoff_AllFail(t *testing.T) {
 	calls := 0
 	want := errors.New("persistent error")
-	err := RetryWithBackoff(2, 10*time.Millisecond, func() error {
+	err := RetryWithBackoff(context.Background(), 2, 10*time.Millisecond, func() error {
 		calls++
 		return want
 	})
@@ -57,7 +58,7 @@ func TestRetryWithBackoff_AllFail(t *testing.T) {
 
 func TestRetryWithBackoff_PermanentError(t *testing.T) {
 	calls := 0
-	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+	err := RetryWithBackoff(context.Background(), 3, 10*time.Millisecond, func() error {
 		calls++
 		return PermanentError{Err: errors.New("not found")}
 	})
@@ -75,12 +76,30 @@ func TestRetryWithBackoff_PermanentError(t *testing.T) {
 
 func TestRetryWithBackoff_ZeroRetries(t *testing.T) {
 	calls := 0
-	err := RetryWithBackoff(0, 10*time.Millisecond, func() error {
+	err := RetryWithBackoff(context.Background(), 0, 10*time.Millisecond, func() error {
 		calls++
 		return errors.New("fail")
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := RetryWithBackoff(ctx, 5, 50*time.Millisecond, func() error {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return errors.New("transient")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	if calls != 1 {
 		t.Errorf("expected 1 call, got %d", calls)

--- a/api/pkg/utils/retry_test.go
+++ b/api/pkg/utils/retry_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryWithBackoff_SuccessFirst(t *testing.T) {
+	calls := 0
+	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_SuccessAfterRetries(t *testing.T) {
+	calls := 0
+	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_AllFail(t *testing.T) {
+	calls := 0
+	want := errors.New("persistent error")
+	err := RetryWithBackoff(2, 10*time.Millisecond, func() error {
+		calls++
+		return want
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != want.Error() {
+		t.Errorf("expected %q, got %q", want, err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (initial + 2 retries), got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_PermanentError(t *testing.T) {
+	calls := 0
+	err := RetryWithBackoff(3, 10*time.Millisecond, func() error {
+		calls++
+		return PermanentError{Err: errors.New("not found")}
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+	var perm PermanentError
+	if !errors.As(err, &perm) {
+		t.Errorf("expected PermanentError, got %T", err)
+	}
+}
+
+func TestRetryWithBackoff_ZeroRetries(t *testing.T) {
+	calls := 0
+	err := RetryWithBackoff(0, 10*time.Millisecond, func() error {
+		calls++
+		return errors.New("fail")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}


### PR DESCRIPTION
Split GitHub HTML parse from image fetches, scrape with a timeout + retry, and keep avatar order after parallel fetch. Handlers take store/renderer interfaces so tests cover cache miss, persist, and auth without Badger or live GitHub.