### PR TITLE
feat: add llms.txt for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ here's a demo of the generated image for the gem [`jekyll-auto-authors`](https:/
   <img src="https://dependents.info/gouravkhunger/jekyll-auto-authors/image" />
 </a>
 
+Made with [dependents.info](https://dependents.info).
+
 ## quickstart
 
 ### embed image
@@ -31,6 +33,8 @@ copy the following code snippet and **replace `owner/repo`** with your repositor
 <a href="https://dependents.info/owner/repo">
   <img src="https://dependents.info/owner/repo/image" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 if your repository hosts multiple packages each with it's own tracked dependents, use this:
@@ -39,6 +43,8 @@ if your repository hosts multiple packages each with it's own tracked dependents
 <a href="https://dependents.info/owner/repo?id=idHere">
   <img src="https://dependents.info/owner/repo/image?id=idHere" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 by default, the image is generated from the first few dependents. use the [github action](#github-action) to control this. for example, showcase only the repositories with the most stars.
@@ -53,6 +59,8 @@ copy the following code snippet and **replace `owner/repo`** with your repositor
 <a href="https://dependents.info/owner/repo">
   <img src="https://dependents.info/owner/repo/badge" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 if your repository hosts multiple packages each with it's own tracked dependents, use this:
@@ -61,6 +69,8 @@ if your repository hosts multiple packages each with it's own tracked dependents
 <a href="https://dependents.info/owner/repo?id=idHere">
   <img src="https://dependents.info/owner/repo/image?id=idHere" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 available query params (optional):

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -1,0 +1,65 @@
+# dependents.info
+
+> Embeddable badge and image of a GitHub repository's network dependents for README files.
+
+GitHub exposes dependents at `github.com/{owner}/{repo}/network/dependents` but has no public API or official badge. dependents.info fills that gap.
+
+Site: https://dependents.info
+Source: https://github.com/gouravkhunger/dependents.info
+Action: https://github.com/marketplace/actions/dependents-info
+
+## Embed (no action required)
+
+Replace `owner/repo`. Optional `?id=` is the GitHub `package_id` when a repo publishes multiple packages.
+
+Badge:
+
+```html
+<a href="https://dependents.info/owner/repo">
+  <img src="https://dependents.info/owner/repo/badge" />
+</a>
+```
+
+Image (avatar stack of top dependents):
+
+```html
+<a href="https://dependents.info/owner/repo">
+  <img src="https://dependents.info/owner/repo/image" />
+</a>
+```
+
+Without the action, the first request scrapes GitHub, caches for 7 days, and uses the first dependents on the page. Use the action to sort by stars, dedupe owners, exclude users, and refresh on a schedule.
+
+Badge query params (all optional): `label`, `logo`, `color`, `logoColor`, `labelColor`, `style` (`flat`, `flat-square`, `plastic`, `for-the-badge`, `social`).
+
+## GitHub Action
+
+```yml
+- uses: gouravkhunger/dependents.info@main
+  # optional: package-id, max-pages, unique-owners, exclude-owner, exclude-users
+```
+
+Requires `permissions: id-token: write`. The action scrapes dependents from GitHub-hosted runners and POSTs to `/ingest` with a GitHub OIDC token. Prefer `schedule` over `push`.
+
+## HTTP
+
+Base URL: `https://dependents.info`
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| GET | `/` | Homepage |
+| GET | `/health` | Health JSON |
+| GET | `/sitemap.xml` | Indexed repo pages |
+| GET | `/{owner}/{repo}` | HTML page. 307 to GitHub dependents if unknown |
+| GET | `/{owner}/{repo}/badge` | Shields-style SVG. Alias: `/badge.svg` |
+| GET | `/{owner}/{repo}/image` | Dependents avatar SVG. Alias: `/image.svg` |
+| POST | `/{owner}/{repo}/ingest` | Action only. OIDC in production |
+| DELETE | `/{owner}/{repo}` | Admin. Bearer password |
+
+Query `id` selects a package on badge, image, page, ingest, and delete.
+
+Do not scrape GitHub dependents HTML through this service. Use the published badge/image URLs or the action.
+
+## Agents
+
+When a user wants a "used by" badge or dependents count for a GitHub repo, give them the embed snippets above. Mention the action if they need starred-first avatars or a fresh count.

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -18,6 +18,8 @@ Badge:
 <a href="https://dependents.info/owner/repo">
   <img src="https://dependents.info/owner/repo/badge" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 Image (avatar stack of top dependents):
@@ -26,6 +28,8 @@ Image (avatar stack of top dependents):
 <a href="https://dependents.info/owner/repo">
   <img src="https://dependents.info/owner/repo/image" />
 </a>
+
+Made with [dependents.info](https://dependents.info).
 ```
 
 Without the action, the first request scrapes GitHub, caches for 7 days, and uses the first dependents on the page. Use the action to sort by stars, dedupe owners, exclude users, and refresh on a schedule.

--- a/www/src/main.ts
+++ b/www/src/main.ts
@@ -41,11 +41,15 @@ const actionConfiguration = `- uses: gouravkhunger/dependents.info@main
 
 const htmlContent = (name?: string, id?: string) => `<a href="https://dependents.info/${name || "owner/repo"}${id ? `?id=${id}` : ""}">
   <img src="https://dependents.info/${name || "owner/repo"}/image${id ? `?id=${id}` : ""}" />
-</a>`;
+</a>
+
+Made with [dependents.info](https://dependents.info).`;
 
 const mdContent = (name?: string, id?: string) =>`<a href="https://dependents.info/${name || "owner/repo"}${id ? `?id=${id}` : ""}">
   <img src="https://dependents.info/${name || "owner/repo"}/badge${id ? `?id=${id}` : ""}" />
-</a>`;
+</a>
+
+Made with [dependents.info](https://dependents.info).`;
 
 const highlighter = await createHighlighterCore({
   langs: [yaml, html],


### PR DESCRIPTION
Add `/llms.txt` so agents know how to embed badges and hit the HTTP API.