### PR TITLE
feat(api): add shields.json endpoint

### DIFF
--- a/api/internal/handlers/badge.go
+++ b/api/internal/handlers/badge.go
@@ -27,10 +27,7 @@ func NewBadgeHandler(
 	}
 }
 
-func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
-	id := c.Query("id")
-	repo := c.Params("owner") + "/" + c.Params("repo")
-
+func (h *BadgeHandler) resolveTotal(repo, id string) (string, error) {
 	name := repo
 	if id != "" {
 		name += ":" + id
@@ -38,15 +35,22 @@ func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
 
 	var total string
 	err := h.databaseService.Get("total:"+name, &total)
-
 	if err != nil {
 		h.dependentsService.NewTask(repo, id, "badge", func(total int, svg []byte) {
 			h.databaseService.SaveWithTTL("total:"+name, []byte(strconv.Itoa(total)), 7*24*time.Hour)
 		})
 		err = h.databaseService.Get("total:"+name, &total)
-		if err != nil {
-			return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
-		}
+	}
+	return total, err
+}
+
+func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
+	id := c.Query("id")
+	repo := c.Params("owner") + "/" + c.Params("repo")
+
+	total, err := h.resolveTotal(repo, id)
+	if err != nil {
+		return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
 	}
 	body, err := getBadge(total, c.Queries())
 	if err != nil {
@@ -56,6 +60,26 @@ func (h *BadgeHandler) Badge(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusOK).Type("svg").Send(body)
 }
 
+func (h *BadgeHandler) Shields(c *fiber.Ctx) error {
+	id := c.Query("id")
+	repo := c.Params("owner") + "/" + c.Params("repo")
+
+	total, err := h.resolveTotal(repo, id)
+	if err != nil {
+		return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
+	}
+
+	totalInt, _ := strconv.Atoi(total)
+	label := c.Query("label", "dependents")
+	c.Set(fiber.HeaderCacheControl, "public, max-age=86400, must-revalidate")
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"schemaVersion": 1,
+		"label":         label,
+		"message":       utils.FormatNumber(totalInt),
+		"color":         color(total),
+		"cacheSeconds":  86400,
+	})
+}
 
 func (h *BadgeHandler) SelfBadge(c *fiber.Ctx) error {
 	var total string

--- a/api/internal/handlers/badge_test.go
+++ b/api/internal/handlers/badge_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -59,4 +61,83 @@ func TestBadgeHandler_Badge(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBadgeHandler_Shields(t *testing.T) {
+	cfg := test.NewConfig()
+	cfg.DatabasePath = "/tmp/dependents-test-shields"
+	imageService := render.NewRenderService()
+	dbService := database.NewBadgerService(cfg.DatabasePath)
+	dependentsService := github.NewDependentsService(imageService)
+	dbService.Save("total:owner/repo", []byte("69"))
+	dbService.Save("total:owner/repo:pkg1", []byte("1200"))
+	defer dbService.Close()
+
+	app := test.NewServer(cfg)
+	h := NewBadgeHandler(dbService, dependentsService)
+	app.Get("/:owner/:repo/shields.json", h.Shields)
+
+	t.Run("cached total", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo/shields.json", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if payload["schemaVersion"] != float64(1) {
+			t.Errorf("schemaVersion = %v", payload["schemaVersion"])
+		}
+		if payload["label"] != "dependents" {
+			t.Errorf("label = %v", payload["label"])
+		}
+		if payload["message"] != "69" {
+			t.Errorf("message = %v", payload["message"])
+		}
+		if payload["color"] != "yellowgreen" {
+			t.Errorf("color = %v", payload["color"])
+		}
+	})
+
+	t.Run("package id and label override", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo/shields.json?id=pkg1&label=used%20by", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if payload["label"] != "used by" {
+			t.Errorf("label = %v", payload["label"])
+		}
+		if payload["message"] != "1.2K" {
+			t.Errorf("message = %v", payload["message"])
+		}
+		if payload["color"] != "brightgreen" {
+			t.Errorf("color = %v", payload["color"])
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/missing/repo/shields.json", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("expected 404, got %d", resp.StatusCode)
+		}
+	})
 }

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -16,9 +16,10 @@ func Setup(app *fiber.App, handlers *handlers.Handlers) {
 
 	app.Get("/:owner/:repo/badge", handlers.BadgeHandler.Badge)
 	app.Get("/:owner/:repo/image", handlers.ImageHandler.SVGImage)
-	
+	app.Get("/:owner/:repo/shields.json", handlers.BadgeHandler.Shields)
+
 	app.Get("/:owner/:repo/badge.svg", handlers.BadgeHandler.Badge)
 	app.Get("/:owner/:repo/image.svg", handlers.ImageHandler.SVGImage)
-	
+
 	app.Post("/:owner/:repo/ingest", handlers.IngestHandler.Ingest)
 }

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -36,6 +36,12 @@ Without the action, the first request scrapes GitHub, caches for 7 days, and use
 
 Badge query params (all optional): `label`, `logo`, `color`, `logoColor`, `labelColor`, `style` (`flat`, `flat-square`, `plastic`, `for-the-badge`, `social`).
 
+Shields.io endpoint (uses this service as the JSON source):
+
+```
+https://img.shields.io/endpoint?url=https://dependents.info/owner/repo/shields.json
+```
+
 ## GitHub Action
 
 ```yml
@@ -57,6 +63,7 @@ Base URL: `https://dependents.info`
 | GET | `/{owner}/{repo}` | HTML page. 307 to GitHub dependents if unknown |
 | GET | `/{owner}/{repo}/badge` | Shields-style SVG. Alias: `/badge.svg` |
 | GET | `/{owner}/{repo}/image` | Dependents avatar SVG. Alias: `/image.svg` |
+| GET | `/{owner}/{repo}/shields.json` | [Shields endpoint](https://shields.io/badges/endpoint-badge) JSON |
 | POST | `/{owner}/{repo}/ingest` | Action only. OIDC in production |
 | DELETE | `/{owner}/{repo}` | Admin. Bearer password |
 


### PR DESCRIPTION
Stacks on #23.

`GET /{owner}/{repo}/shields.json` returns Shields endpoint JSON so badges can be `img.shields.io/endpoint?url=...`.