### PR TITLE
feat(api): serve repo pages as json and markdown

### DIFF
--- a/api/internal/handlers/repo.go
+++ b/api/internal/handlers/repo.go
@@ -140,16 +140,21 @@ func repoMarkdown(host, owner, repo, id string, total int, hasImage bool) string
 		q = "?id=" + id
 	}
 	name := owner + "/" + repo
+	using := "repository's default package"
+	if id != "" {
+		using = "package"
+	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "# %s\n\n", name)
 	if id != "" {
-		fmt.Fprintf(&b, "package `%s`\n\n", id)
+		fmt.Fprintf(&b, "## package: %s\n\n", id)
 	}
-	fmt.Fprintf(&b, "**%s** GitHub network dependents.\n\n", utils.FormatNumber(total))
+	fmt.Fprintf(&b, "found **%s projects** (network dependents) using this github %s!\n\n", utils.FormatNumber(total), using)
 	fmt.Fprintf(&b, "[![dependents](%s/%s/badge%s)](%s/%s%s)\n", host, name, q, host, name, q)
 	if hasImage {
 		fmt.Fprintf(&b, "\n![used by](%s/%s/image%s)\n", host, name, q)
 	}
+	fmt.Fprintf(&b, "\nMade with [dependents.info](%s).\n", host)
 	gh := "https://github.com/" + name + "/network/dependents"
 	if id != "" {
 		gh += "?package_id=" + id

--- a/api/internal/handlers/repo.go
+++ b/api/internal/handlers/repo.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -24,10 +26,21 @@ func NewRepoHandler(databaseService *database.BadgerService, renderService *rend
 	}
 }
 
+func splitRepoFormat(raw string) (repo, format string) {
+	switch {
+	case strings.HasSuffix(raw, ".json"):
+		return strings.TrimSuffix(raw, ".json"), "json"
+	case strings.HasSuffix(raw, ".md"):
+		return strings.TrimSuffix(raw, ".md"), "md"
+	default:
+		return raw, "html"
+	}
+}
+
 func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 	id := c.Query("id")
-	repo := c.Params("repo")
 	owner := c.Params("owner")
+	repo, format := splitRepoFormat(c.Params("repo"))
 	name := owner + "/" + repo
 	cfg := config.FromContext(c.UserContext())
 
@@ -39,6 +52,9 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 	err := h.databaseService.Get("total:"+name, &total)
 
 	if err != nil {
+		if format != "html" {
+			return utils.SendError(c, fiber.StatusNotFound, "Total dependents not found", err)
+		}
 		url := "https://github.com/" + owner + "/" + repo + "/network/dependents"
 		if id != "" {
 			url += "?package_id=" + id
@@ -54,9 +70,20 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 	}
 
 	totalInt, _ := strconv.Atoi(total)
+	hasImage := image != ""
+	c.Set(fiber.HeaderCacheControl, "public, max-age=86400, must-revalidate")
+
+	if format == "json" {
+		return c.Status(fiber.StatusOK).JSON(repoJSON(cfg.Host(), owner, repo, id, totalInt, hasImage))
+	}
+	if format == "md" {
+		c.Type("md")
+		return c.Status(fiber.StatusOK).SendString(repoMarkdown(cfg.Host(), owner, repo, id, totalInt, hasImage))
+	}
+
 	data := models.RepoPage{
 		StylesFile: cfg.StylesFile,
-		HasImage:   image != "",
+		HasImage:   hasImage,
 		Total:      totalInt,
 		Owner:      owner,
 		Repo:       repo,
@@ -73,6 +100,62 @@ func (h *RepoHandler) RepoPage(c *fiber.Ctx) error {
 		c.Set(fiber.HeaderXRobotsTag, "noindex, nofollow")
 	}
 
-	c.Set(fiber.HeaderCacheControl, "public, max-age=86400, must-revalidate")
 	return c.Status(fiber.StatusOK).Type("html").Send(page)
+}
+
+func repoJSON(host, owner, repo, id string, total int, hasImage bool) fiber.Map {
+	q := ""
+	if id != "" {
+		q = "?id=" + id
+	}
+	name := owner + "/" + repo
+	gh := "https://github.com/" + name + "/network/dependents"
+	if id != "" {
+		gh += "?package_id=" + id
+	}
+	payload := fiber.Map{
+		"owner":     owner,
+		"repo":      repo,
+		"total":     total,
+		"has_image": hasImage,
+		"urls": fiber.Map{
+			"page":              host + "/" + name + q,
+			"badge":             host + "/" + name + "/badge" + q,
+			"image":             host + "/" + name + "/image" + q,
+			"markdown":          host + "/" + name + ".md" + q,
+			"json":              host + "/" + name + ".json" + q,
+			"shields":           host + "/" + name + "/shields.json" + q,
+			"github_dependents": gh,
+		},
+	}
+	if id != "" {
+		payload["id"] = id
+	}
+	return payload
+}
+
+func repoMarkdown(host, owner, repo, id string, total int, hasImage bool) string {
+	q := ""
+	if id != "" {
+		q = "?id=" + id
+	}
+	name := owner + "/" + repo
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", name)
+	if id != "" {
+		fmt.Fprintf(&b, "package `%s`\n\n", id)
+	}
+	fmt.Fprintf(&b, "**%s** GitHub network dependents.\n\n", utils.FormatNumber(total))
+	fmt.Fprintf(&b, "[![dependents](%s/%s/badge%s)](%s/%s%s)\n", host, name, q, host, name, q)
+	if hasImage {
+		fmt.Fprintf(&b, "\n![used by](%s/%s/image%s)\n", host, name, q)
+	}
+	gh := "https://github.com/" + name + "/network/dependents"
+	if id != "" {
+		gh += "?package_id=" + id
+	}
+	fmt.Fprintf(&b, "\n- [dependents.info](%s/%s%s)\n", host, name, q)
+	fmt.Fprintf(&b, "- [GitHub dependents](%s)\n", gh)
+	fmt.Fprintf(&b, "- [JSON](%s/%s.json%s)\n", host, name, q)
+	return b.String()
 }

--- a/api/internal/handlers/repo_test.go
+++ b/api/internal/handlers/repo_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"dependents.info/internal/service/database"
+	"dependents.info/internal/service/render"
+	"dependents.info/internal/test"
+)
+
+func TestRepoHandler_Formats(t *testing.T) {
+	cfg := test.NewConfig()
+	cfg.DatabasePath = "/tmp/dependents-test-repo-formats"
+	dbService := database.NewBadgerService(cfg.DatabasePath)
+	dbService.Save("total:owner/repo", []byte("42"))
+	dbService.Save("svg:owner/repo", []byte("<svg/>"))
+	dbService.Save("total:owner/repo:pkg1", []byte("7"))
+	defer dbService.Close()
+
+	app := test.NewServer(cfg)
+	h := NewRepoHandler(dbService, render.NewRenderService())
+	app.Get("/:owner/:repo", h.RepoPage)
+
+	t.Run("json", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo.json", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if payload["owner"] != "owner" || payload["repo"] != "repo" {
+			t.Errorf("owner/repo = %v/%v", payload["owner"], payload["repo"])
+		}
+		if payload["total"] != float64(42) {
+			t.Errorf("total = %v", payload["total"])
+		}
+		if payload["has_image"] != true {
+			t.Errorf("has_image = %v", payload["has_image"])
+		}
+		urls, _ := payload["urls"].(map[string]any)
+		if urls["json"] != "http://localhost:5000/owner/repo.json" {
+			t.Errorf("urls.json = %v", urls["json"])
+		}
+		if urls["shields"] != "http://localhost:5000/owner/repo/shields.json" {
+			t.Errorf("urls.shields = %v", urls["shields"])
+		}
+	})
+
+	t.Run("markdown", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo.md", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		text := string(body)
+		if !strings.Contains(text, "# owner/repo") {
+			t.Errorf("missing heading: %s", text)
+		}
+		if !strings.Contains(text, "42") {
+			t.Errorf("missing total: %s", text)
+		}
+		if !strings.Contains(text, "/owner/repo/badge") {
+			t.Errorf("missing badge: %s", text)
+		}
+		if !strings.Contains(text, "/owner/repo/image") {
+			t.Errorf("missing image: %s", text)
+		}
+	})
+
+	t.Run("json with package id", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo.json?id=pkg1", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if payload["id"] != "pkg1" {
+			t.Errorf("id = %v", payload["id"])
+		}
+		if payload["total"] != float64(7) {
+			t.Errorf("total = %v", payload["total"])
+		}
+		if payload["has_image"] != false {
+			t.Errorf("has_image = %v", payload["has_image"])
+		}
+	})
+
+	t.Run("json missing", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/missing/repo.json", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("html still works", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/internal/handlers/repo_test.go
+++ b/api/internal/handlers/repo_test.go
@@ -73,14 +73,36 @@ func TestRepoHandler_Formats(t *testing.T) {
 		if !strings.Contains(text, "# owner/repo") {
 			t.Errorf("missing heading: %s", text)
 		}
-		if !strings.Contains(text, "42") {
-			t.Errorf("missing total: %s", text)
+		if !strings.Contains(text, "found **42 projects** (network dependents) using this github repository's default package!") {
+			t.Errorf("missing wording: %s", text)
 		}
 		if !strings.Contains(text, "/owner/repo/badge") {
 			t.Errorf("missing badge: %s", text)
 		}
 		if !strings.Contains(text, "/owner/repo/image") {
 			t.Errorf("missing image: %s", text)
+		}
+		if !strings.Contains(text, "Made with [dependents.info](http://localhost:5000).") {
+			t.Errorf("missing made with: %s", text)
+		}
+	})
+
+	t.Run("markdown with package id", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/owner/repo.md?id=pkg1", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		text := string(body)
+		if !strings.Contains(text, "## package: pkg1") {
+			t.Errorf("missing package heading: %s", text)
+		}
+		if !strings.Contains(text, "found **7 projects** (network dependents) using this github package!") {
+			t.Errorf("missing package wording: %s", text)
 		}
 	})
 

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -61,6 +61,8 @@ Base URL: `https://dependents.info`
 | GET | `/health` | Health JSON |
 | GET | `/sitemap.xml` | Indexed repo pages |
 | GET | `/{owner}/{repo}` | HTML page. 307 to GitHub dependents if unknown |
+| GET | `/{owner}/{repo}.json` | JSON document (404 if unknown) |
+| GET | `/{owner}/{repo}.md` | Markdown document (404 if unknown) |
 | GET | `/{owner}/{repo}/badge` | Shields-style SVG. Alias: `/badge.svg` |
 | GET | `/{owner}/{repo}/image` | Dependents avatar SVG. Alias: `/image.svg` |
 | GET | `/{owner}/{repo}/shields.json` | [Shields endpoint](https://shields.io/badges/endpoint-badge) JSON |
@@ -74,3 +76,5 @@ Do not scrape GitHub dependents HTML through this service. Use the published bad
 ## Agents
 
 When a user wants a "used by" badge or dependents count for a GitHub repo, give them the embed snippets above. Mention the action if they need starred-first avatars or a fresh count.
+
+Prefer `GET /{owner}/{repo}.json` for tool use. Use `.md` when pasting into a document.


### PR DESCRIPTION
Stacks on #24.

`GET /{owner}/{repo}.json` and `GET /{owner}/{repo}.md`. Unknown repos 404 instead of redirecting to GitHub.