### PR TITLE
feat(www): add used by cards on homepage

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -68,6 +68,11 @@
       <a href="/gouravkhunger/jekyll-auto-authors">
         <img src="/gouravkhunger/jekyll-auto-authors/image" alt="Network dependents preview for GitHub repo gouravkhunger/jekyll-auto-authors" />
       </a>
+      <section id="used-by-section" hidden>
+        <h2>used by</h2>
+        <p>projects already embedding dependents.info:</p>
+        <div class="used-by not-prose" id="used-by"></div>
+      </section>
       <h2>watch</h2>
       <iframe
         frameborder="0"

--- a/www/index.html
+++ b/www/index.html
@@ -68,11 +68,51 @@
       <a href="/gouravkhunger/jekyll-auto-authors">
         <img src="/gouravkhunger/jekyll-auto-authors/image" alt="Network dependents preview for GitHub repo gouravkhunger/jekyll-auto-authors" />
       </a>
-      <section id="used-by-section" hidden>
-        <h2>used by</h2>
-        <p>projects already embedding dependents.info:</p>
-        <div class="used-by not-prose" id="used-by"></div>
-      </section>
+      <h2>used by</h2>
+      <div class="used-by not-prose">
+        <a class="used-by-card" href="/joshnuss/svelte-persisted-store">
+          <img src="https://github.com/joshnuss.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">joshnuss/svelte-persisted-store</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+        <a class="used-by-card" href="/sieblyio/binance">
+          <img src="https://github.com/sieblyio.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">sieblyio/binance</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+        <a class="used-by-card" href="/oekazuma/svelte-meta-tags">
+          <img src="https://github.com/oekazuma.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">oekazuma/svelte-meta-tags</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+        <a class="used-by-card" href="/okineadev/vitepress-plugin-llms">
+          <img src="https://github.com/okineadev.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">okineadev/vitepress-plugin-llms</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+        <a class="used-by-card" href="/SSShooter/mind-elixir-core">
+          <img src="https://github.com/SSShooter.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">SSShooter/mind-elixir-core</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+        <a class="used-by-card" href="/HatsuneMiku3939/direnv-action">
+          <img src="https://github.com/HatsuneMiku3939.png?size=64" width="32" height="32" alt="" />
+          <div class="used-by-meta">
+            <span class="used-by-name">HatsuneMiku3939/direnv-action</span>
+            <span class="used-by-stars"></span>
+          </div>
+        </a>
+      </div>
       <h2>watch</h2>
       <iframe
         frameborder="0"

--- a/www/src/main.ts
+++ b/www/src/main.ts
@@ -121,69 +121,18 @@ packageIdInputElement.addEventListener("input", (e) => {
   embedCodeElement.innerHTML = embedCode(invalid ? undefined : repo, id);
 });
 
-const usedByRepos = [
-  "joshnuss/svelte-persisted-store",
-  "sieblyio/binance",
-  "oekazuma/svelte-meta-tags",
-  "okineadev/vitepress-plugin-llms",
-  "SSShooter/mind-elixir-core",
-  "HatsuneMiku3939/direnv-action",
-];
-
-const usedBy = document.querySelector("#used-by");
-const usedBySection = document.querySelector<HTMLElement>("#used-by-section");
-
-if (usedBy && usedBySection) {
-  const rows = await Promise.all(
-    usedByRepos.map(async (repo) => {
-      try {
-        const res = await fetch(`https://dependents.info/${repo}.json`);
-        if (!res.ok) {
-          return null;
-        }
-        const data = (await res.json()) as { owner?: string; repo?: string; total?: number };
-        const owner = data.owner ?? repo.split("/")[0];
-        const name = data.repo ?? repo.split("/")[1];
-        const total = typeof data.total === "number" ? data.total : 0;
-        return { owner, name, total };
-      } catch {
-        return null;
-      }
-    }),
-  );
-
-  for (const row of rows) {
-    if (!row) {
-      continue;
+document.querySelectorAll<HTMLAnchorElement>(".used-by-card").forEach(async (card) => {
+  const slug = card.getAttribute("href")?.replace(/^\//, "");
+  const el = card.querySelector(".used-by-stars");
+  if (!slug || !el) return;
+  try {
+    const res = await fetch(`/${slug}.json`);
+    if (!res.ok) {
+      return;
     }
-    const slug = `${row.owner}/${row.name}`;
-    const a = document.createElement("a");
-    a.className = "used-by-card";
-    a.href = `/${slug}`;
-
-    const img = document.createElement("img");
-    img.src = `https://github.com/${row.owner}.png?size=64`;
-    img.width = 32;
-    img.height = 32;
-    img.alt = "";
-
-    const meta = document.createElement("div");
-    meta.className = "used-by-meta";
-
-    const title = document.createElement("span");
-    title.className = "used-by-name";
-    title.textContent = slug;
-
-    const stars = document.createElement("span");
-    stars.className = "used-by-stars";
-    stars.textContent = `${row.total.toLocaleString("en-US")} dependents`;
-
-    meta.append(title, stars);
-    a.append(img, meta);
-    usedBy.append(a);
-  }
-
-  if (usedBy.childElementCount > 0) {
-    usedBySection.hidden = false;
-  }
-}
+    const data = (await res.json()) as { total?: number };
+    if (typeof data.total === "number") {
+      el.textContent = `${data.total.toLocaleString("en-US")} dependents`;
+    }
+  } catch {}
+});

--- a/www/src/main.ts
+++ b/www/src/main.ts
@@ -120,3 +120,70 @@ packageIdInputElement.addEventListener("input", (e) => {
   badgeCodeElement.innerHTML = badgeCode(invalid ? undefined : repo, id);
   embedCodeElement.innerHTML = embedCode(invalid ? undefined : repo, id);
 });
+
+const usedByRepos = [
+  "joshnuss/svelte-persisted-store",
+  "sieblyio/binance",
+  "oekazuma/svelte-meta-tags",
+  "okineadev/vitepress-plugin-llms",
+  "SSShooter/mind-elixir-core",
+  "HatsuneMiku3939/direnv-action",
+];
+
+const usedBy = document.querySelector("#used-by");
+const usedBySection = document.querySelector<HTMLElement>("#used-by-section");
+
+if (usedBy && usedBySection) {
+  const rows = await Promise.all(
+    usedByRepos.map(async (repo) => {
+      try {
+        const res = await fetch(`https://dependents.info/${repo}.json`);
+        if (!res.ok) {
+          return null;
+        }
+        const data = (await res.json()) as { owner?: string; repo?: string; total?: number };
+        const owner = data.owner ?? repo.split("/")[0];
+        const name = data.repo ?? repo.split("/")[1];
+        const total = typeof data.total === "number" ? data.total : 0;
+        return { owner, name, total };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  for (const row of rows) {
+    if (!row) {
+      continue;
+    }
+    const slug = `${row.owner}/${row.name}`;
+    const a = document.createElement("a");
+    a.className = "used-by-card";
+    a.href = `/${slug}`;
+
+    const img = document.createElement("img");
+    img.src = `https://github.com/${row.owner}.png?size=64`;
+    img.width = 32;
+    img.height = 32;
+    img.alt = "";
+
+    const meta = document.createElement("div");
+    meta.className = "used-by-meta";
+
+    const title = document.createElement("span");
+    title.className = "used-by-name";
+    title.textContent = slug;
+
+    const stars = document.createElement("span");
+    stars.className = "used-by-stars";
+    stars.textContent = `${row.total.toLocaleString("en-US")} dependents`;
+
+    meta.append(title, stars);
+    a.append(img, meta);
+    usedBy.append(a);
+  }
+
+  if (usedBy.childElementCount > 0) {
+    usedBySection.hidden = false;
+  }
+}

--- a/www/src/style.css
+++ b/www/src/style.css
@@ -61,6 +61,32 @@
   @apply no-underline border-2 border-gray-300 text-gray-700 hover:bg-gray-100;
 }
 
+.used-by {
+  @apply grid grid-cols-1 sm:grid-cols-2 gap-2 my-4;
+}
+
+.used-by-card {
+  @apply flex items-center gap-3 no-underline text-gray-800;
+  @apply border-2 border-gray-300 rounded-md px-3 py-2;
+  @apply hover:bg-gray-100 transition-colors duration-200;
+}
+
+.used-by-card img {
+  @apply !m-0 size-8 rounded-md shrink-0;
+}
+
+.used-by-meta {
+  @apply flex flex-col min-w-0 gap-0.5;
+}
+
+.used-by-name {
+  @apply text-sm truncate;
+}
+
+.used-by-stars {
+  @apply text-xs text-gray-600;
+}
+
 /* https://github.com/joshnuss/shiki-transformer-copy-button */
 pre:has(code) {
   @apply relative flex p-0;


### PR DESCRIPTION
Replace the recent-badge cloud with six hardcoded Used by cards. Counts come from each repo's `.json`.

Unique owners from sitemap.xml:

- joshnuss/svelte-persisted-store
- sieblyio/binance
- oekazuma/svelte-meta-tags
- okineadev/vitepress-plugin-llms
- SSShooter/mind-elixir-core
- HatsuneMiku3939/direnv-action